### PR TITLE
Pinning rack version to 1.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'sinatra'
+gem 'rack', '1.5.2'
 gem 'encryptor'
 gem 'memcached'
 gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ PLATFORMS
 DEPENDENCIES
   encryptor
   memcached
+  rack (= 1.5.2)
   rake
   rspec
   sinatra


### PR DESCRIPTION
Yopass 2.2.0 doesn't work with rack 1.6.0, raising the following error:

```
App 6242 stderr: [ 2015-01-20 16:25:00.5547 6258/0x00000000a92ae0(Worker 1) utils.rb:68 ]: *** Exception NameError in Rack application object (uninitialized constant Rack::Request::QUERY_STRING) (process 6258, thread 0x00000000a92ae0(Worker 1)):
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/rack-1.6.0/lib/rack/request.rb:24:in `query_string'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/rack-1.6.0/lib/rack/request.rb:188:in `GET'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/rack-1.6.0/lib/rack/request.rb:230:in `params'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:893:in `call!'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:886:in `call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/rack-protection-1.5.3/lib/rack/protection/xss_header.rb:18:in `call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/rack-protection-1.5.3/lib/rack/protection/path_traversal.rb:16:in `call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/rack-protection-1.5.3/lib/rack/protection/json_csrf.rb:18:in `call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/rack-protection-1.5.3/lib/rack/protection/frame_options.rb:31:in `call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/rack-1.6.0/lib/rack/nulllogger.rb:9:in `call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/rack-1.6.0/lib/rack/head.rb:13:in `call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:180:in `call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:2014:in `call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:1478:in `block in call'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:1788:in `synchronize'
App 6242 stderr: 	from /var/lib/gems/2.0.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:1478:in `call'
App 6242 stderr: 	from /usr/lib/ruby/vendor_ruby/phusion_passenger/rack/thread_handler_extension.rb:77:in `process_request'
App 6242 stderr: 	from /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:142:in `accept_and_process_next_request'
App 6242 stderr: 	from /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:110:in `main_loop'
App 6242 stderr: 	from /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler.rb:448:in `block (3 levels) in start_threads'
```