### PR TITLE
Support keyboard shortcuts (Ctrl+Enter) for submit.

### DIFF
--- a/website/src/Create.tsx
+++ b/website/src/Create.tsx
@@ -61,6 +61,14 @@ const Create = () => {
     setLoading(false);
   };
 
+  const onKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ): void => {
+    if (event.ctrlKey && event.key === "Enter") {
+      submit();
+    }
+  }
+
   return (
     <div className="text-center">
       <h1>{t('Encrypt message')}</h1>
@@ -79,6 +87,7 @@ const Create = () => {
               placeholder={t('Message to encrypt locally in your browser')}
               onChange={(e) => setSecret(e.target.value)}
               value={secret}
+              onKeyDown={onKeyDown}
             />
           </FormGroup>
           <Lifetime expiration={expiration} setExpiration={setExpiration} />


### PR DESCRIPTION
Adressess: #579 

* Makes it possible to submit form by doing <kbd>Ctrl</kbd> + <kbd>Enter</kbd>

Regarding:
> Maybe it would even be possible to be able to copy the one-click link with ctrl+c or some other combination on the next page?

You could focus for example the first input on the next page and run <kbd>Ctrl</kbd> + <kbd>c</kbd> or the equivalent of copying to the clipboard. But `clipboard` does not seem to support that behavior. `clipboard` binds a button to a field and is pretty rigid. You could copy with a lib like https://www.npmjs.com/package/copy-to-clipboard 