### PR TITLE
Use only non ambiguous characters for passwords

### DIFF
--- a/website/src/utils.tsx
+++ b/website/src/utils.tsx
@@ -2,8 +2,7 @@ import * as openpgp from 'openpgp';
 
 export const randomString = (): string => {
   let text = '';
-  const possible =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const possible = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz123456789';
   for (let i = 0; i < 22; i++) {
     text += possible.charAt(randomInt(0, possible.length));
   }


### PR DESCRIPTION
This pull request removes the following characters from the
set of possible password characters: l I O 0

In many fonts these characters look very similar so
it's difficult to enter correct passwords manually,
when not pasted from clipboard.