### PR TITLE
Use strict function return for eslint

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -57,7 +57,13 @@
     "extends": [
       "react-app",
       "react-app/jest"
-    ]
+    ],
+    "rules": {
+      "@typescript-eslint/explicit-function-return-type": [
+        "error",
+        { "allowExpressions": true }
+      ]
+    }
   },
   "browserslist": {
     "production": [

--- a/website/package.json
+++ b/website/package.json
@@ -61,7 +61,9 @@
     "rules": {
       "@typescript-eslint/explicit-function-return-type": [
         "error",
-        { "allowExpressions": true }
+        {
+          "allowExpressions": true
+        }
       ]
     }
   },

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -10,7 +10,7 @@ import Features from './Features';
 import Upload from './Upload';
 import { useTranslation } from 'react-i18next';
 
-const App = () => {
+const App: React.FC = () => {
   return (
     <Router>
       <Navbar color="dark" dark={true} expand="md">
@@ -30,7 +30,7 @@ const App = () => {
   );
 };
 
-const Routes = () => {
+const Routes: React.FC = () => {
   return (
     <div>
       <Route path="/" exact={true} component={Create} />
@@ -47,7 +47,7 @@ const Routes = () => {
   );
 };
 
-const Attribution = () => {
+const Attribution: React.FC = () => {
   const { t } = useTranslation();
   return (
     <Container className="text-center">

--- a/website/src/Create.tsx
+++ b/website/src/Create.tsx
@@ -13,7 +13,7 @@ import Result from './Result';
 import { encryptMessage, postSecret, randomString } from './utils';
 import { useTranslation } from 'react-i18next';
 
-const Create = () => {
+const Create: React.FC = () => {
   const [expiration, setExpiration] = useState(3600);
   const [error, setError] = useState('');
   const [secret, setSecret] = useState('');
@@ -26,7 +26,9 @@ const Create = () => {
 
   const { t } = useTranslation();
 
-  const setSpecifyPasswordAndUpdatePassword = (customPassword: boolean) => {
+  const setSpecifyPasswordAndUpdatePassword = (
+    customPassword: boolean,
+  ): void => {
     setSpecifyPassword(customPassword);
     if (!customPassword) {
       // Clear the manual password if it should be generated.
@@ -34,7 +36,7 @@ const Create = () => {
     }
   };
 
-  const submit = async () => {
+  const submit = async (): Promise<void> => {
     if (!secret) {
       return;
     }
@@ -127,12 +129,12 @@ const Create = () => {
   );
 };
 
-export const OneTime = (
-  props: {
-    readonly onetime: boolean;
-    readonly setOnetime: React.Dispatch<React.SetStateAction<boolean>>;
-  } & React.HTMLAttributes<HTMLElement>,
-) => {
+type OneTimeProps = {
+  readonly onetime: boolean;
+  readonly setOnetime: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export const OneTime: React.FC<OneTimeProps> = (props) => {
   const { t } = useTranslation();
   const { onetime, setOnetime } = props;
   return (
@@ -147,11 +149,14 @@ export const OneTime = (
     </FormGroup>
   );
 };
-export const SpecifyPasswordToggle = (
-  props: {
-    readonly specifyPassword: boolean;
-    readonly setSpecifyPassword: any;
-  } & React.HTMLAttributes<HTMLElement>,
+
+type SpecifyPasswordToggleProps = {
+  readonly specifyPassword: boolean;
+  readonly setSpecifyPassword: any;
+};
+
+export const SpecifyPasswordToggle: React.FC<SpecifyPasswordToggleProps> = (
+  props,
 ) => {
   const { t } = useTranslation();
   const { specifyPassword, setSpecifyPassword } = props;
@@ -174,11 +179,14 @@ export const SpecifyPasswordToggle = (
     </FormGroup>
   );
 };
-export const SpecifyPasswordInput = (
-  props: {
-    readonly password: string;
-    readonly setPassword: React.Dispatch<React.SetStateAction<string>>;
-  } & React.HTMLAttributes<HTMLElement>,
+
+type SpecifyPasswordInputProps = {
+  readonly password: string;
+  readonly setPassword: React.Dispatch<React.SetStateAction<string>>;
+};
+
+export const SpecifyPasswordInput: React.FC<SpecifyPasswordInputProps> = (
+  props,
 ) => {
   const { t } = useTranslation();
   const { password, setPassword } = props;
@@ -197,12 +205,13 @@ export const SpecifyPasswordInput = (
     </FormGroup>
   );
 };
-export const Lifetime = (
-  props: {
-    readonly expiration: number;
-    readonly setExpiration: React.Dispatch<React.SetStateAction<number>>;
-  } & React.HTMLAttributes<HTMLElement>,
-) => {
+
+type LifeTimeProps = {
+  readonly expiration: number;
+  readonly setExpiration: React.Dispatch<React.SetStateAction<number>>;
+};
+
+export const Lifetime: React.FC<LifeTimeProps> = (props) => {
   const { expiration, setExpiration } = props;
   const { t } = useTranslation();
   const buttons = [];
@@ -249,9 +258,12 @@ export const Lifetime = (
   );
 };
 
-export const Error = (
-  props: { readonly message: string } & React.HTMLAttributes<HTMLElement>,
-) =>
+type ErrorProps = {
+  readonly message: string;
+  readonly onClick?: () => void;
+};
+
+export const Error: React.FC<ErrorProps> = (props) =>
   props.message ? (
     <Alert color="danger" {...props}>
       {props.message}

--- a/website/src/DisplaySecret.tsx
+++ b/website/src/DisplaySecret.tsx
@@ -10,7 +10,7 @@ import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { Button } from 'reactstrap';
 import Clipboard from 'clipboard';
 
-const DisplaySecret = () => {
+const DisplaySecret: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, showError] = useState(false);
   const [secret, setSecret] = useState('');
@@ -67,9 +67,11 @@ const DisplaySecret = () => {
   );
 };
 
-const Secret = (
-  props: { readonly secret: string } & React.HTMLAttributes<HTMLElement>,
-) => {
+type SecretProps = {
+  readonly secret: string;
+};
+
+const Secret: React.FC<SecretProps> = (props) => {
   const { t } = useTranslation();
   new Clipboard('#copy-b', {
     target: () => document.getElementById('pre') as Element,

--- a/website/src/Download.tsx
+++ b/website/src/Download.tsx
@@ -7,7 +7,7 @@ import Form from './Form';
 import { decryptMessage } from './utils';
 import { useTranslation } from 'react-i18next';
 
-const Download = () => {
+const Download: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, showError] = useState(false);
   const { key, password } = useParams<DisplayParams>();
@@ -69,7 +69,7 @@ const Download = () => {
   );
 };
 
-const DownloadSuccess = () => {
+const DownloadSuccess: React.FC = () => {
   const { t } = useTranslation();
   return (
     <div>

--- a/website/src/Error.tsx
+++ b/website/src/Error.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
-const Error = (
-  props: { readonly display: boolean } & React.HTMLAttributes<HTMLElement>,
-) => {
+type ErrorProps = {
+  readonly display: boolean;
+};
+
+const Error: React.FC<ErrorProps> = (props) => {
   const { t } = useTranslation();
 
   return props.display ? (

--- a/website/src/Features.tsx
+++ b/website/src/Features.tsx
@@ -12,7 +12,7 @@ import * as React from 'react';
 import { Container, Row } from 'reactstrap';
 import { useTranslation } from 'react-i18next';
 
-const Features = () => {
+const Features: React.FC = () => {
   const { t } = useTranslation();
   return (
     <Container className="features bg-features">
@@ -60,12 +60,12 @@ const Features = () => {
   );
 };
 
-const Feature = (
-  props: {
-    readonly title: string;
-    readonly icon: IconDefinition;
-  } & React.HTMLAttributes<HTMLElement>,
-) => {
+type FeatureProps = {
+  readonly title: string;
+  readonly icon: IconDefinition;
+};
+
+const Feature: React.FC<FeatureProps> = (props) => {
   return (
     <div className="col-lg-4 col-sm-6 col-md-6">
       <div className="feature-box">

--- a/website/src/Form.tsx
+++ b/website/src/Form.tsx
@@ -4,18 +4,18 @@ import { Redirect } from 'react-router-dom';
 import { Button, Col, FormGroup, Input, Label } from 'reactstrap';
 import { useTranslation } from 'react-i18next';
 
-const Form = (
-  props: {
-    readonly display: boolean;
-    readonly uuid: string | undefined;
-    readonly prefix: string;
-  } & React.HTMLAttributes<HTMLElement>,
-) => {
+type FormProps = {
+  readonly display: boolean;
+  readonly uuid: string | undefined;
+  readonly prefix: string;
+};
+
+const Form: React.FC<FormProps> = (props) => {
   const [password, setPassword] = useState('');
   const [redirect, setRedirect] = useState(false);
   const { t } = useTranslation();
 
-  const doRedirect = () => {
+  const doRedirect = (): void => {
     if (password) {
       setRedirect(true);
     }

--- a/website/src/Result.tsx
+++ b/website/src/Result.tsx
@@ -5,13 +5,13 @@ import * as React from 'react';
 import { Button, FormGroup, Input, Label } from 'reactstrap';
 import { useTranslation } from 'react-i18next';
 
-const Result = (
-  props: {
-    readonly uuid: string;
-    readonly password: string;
-    readonly prefix: string;
-  } & React.HTMLAttributes<HTMLElement>,
-) => {
+type ResultProps = {
+  readonly uuid: string;
+  readonly password: string;
+  readonly prefix: string;
+};
+
+const Result: React.FC<ResultProps> = (props) => {
   const { uuid, password, prefix } = props;
   const base = `${window.location.protocol}//${window.location.host}/#/${prefix}`;
   const short = `${base}/${uuid}`;
@@ -40,13 +40,13 @@ const Result = (
   );
 };
 
-const CopyField = (
-  props: {
-    readonly label: string;
-    readonly name: string;
-    readonly value: string;
-  } & React.HTMLAttributes<HTMLElement>,
-) => {
+type CopyFieldProps = {
+  readonly label: string;
+  readonly name: string;
+  readonly value: string;
+};
+
+const CopyField: React.FC<CopyFieldProps> = (props) => {
   new Clipboard(`#${props.name}-b`, {
     target: () => document.getElementById(`${props.name}-i`) as Element,
   });

--- a/website/src/Upload.tsx
+++ b/website/src/Upload.tsx
@@ -16,7 +16,7 @@ import { randomString, uploadFile } from './utils';
 import { useTranslation } from 'react-i18next';
 import { Row } from 'reactstrap';
 
-const Upload = () => {
+const Upload: React.FC = () => {
   const maxSize = 1024 * 500;
   const [password, setPassword] = useState('');
   const [onetime, setOnetime] = useState(true);
@@ -27,7 +27,9 @@ const Upload = () => {
   const [specifyPassword, setSpecifyPassword] = useState(false);
   const [prefix, setPrefix] = useState('');
 
-  const setSpecifyPasswordAndUpdatePassword = (customPassword: boolean) => {
+  const setSpecifyPasswordAndUpdatePassword = (
+    customPassword: boolean,
+  ): void => {
     setSpecifyPassword(customPassword);
     if (!customPassword) {
       // Clear the manual password if it should be generated.

--- a/website/src/utils.tsx
+++ b/website/src/utils.tsx
@@ -1,5 +1,11 @@
 import * as openpgp from 'openpgp';
 
+type Response = {
+  // TODO: this shouldn't be any
+  data: any;
+  status: number;
+};
+
 export const randomString = (): string => {
   let text = '';
   const possible =
@@ -26,15 +32,15 @@ export const BACKEND_DOMAIN = process.env.REACT_APP_BACKEND_URL
   ? `${process.env.REACT_APP_BACKEND_URL}`
   : '';
 
-export const postSecret = async (body: any) => {
+export const postSecret = async (body: any): Promise<Response> => {
   return post(BACKEND_DOMAIN + '/secret', body);
 };
 
-export const uploadFile = async (body: any) => {
+export const uploadFile = async (body: any): Promise<Response> => {
   return post(BACKEND_DOMAIN + '/file', body);
 };
 
-const post = async (url: string, body: any) => {
+const post = async (url: string, body: any): Promise<Response> => {
   const request = await fetch(url, {
     body: JSON.stringify(body),
     method: 'POST',
@@ -46,7 +52,7 @@ export const decryptMessage = async (
   data: string,
   passwords: string,
   format: 'utf8' | 'binary',
-) => {
+): Promise<openpgp.DecryptResult> => {
   const r = await openpgp.decrypt({
     message: await openpgp.message.readArmored(data),
     passwords,
@@ -55,7 +61,10 @@ export const decryptMessage = async (
   return r;
 };
 
-export const encryptMessage = async (data: string, passwords: string) => {
+export const encryptMessage = async (
+  data: string,
+  passwords: string,
+): Promise<string> => {
   const r = await openpgp.encrypt({
     message: openpgp.message.fromText(data),
     passwords,


### PR DESCRIPTION
The default config supplied by `create-react-app` is a bit lax so you may have to add extra  `rules` if the typing should be stricter.

This PR will:
* add the rule [`explicit-function-return-type`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md) which will error if no return type is defined on a function.
* Type up missing return types
* Extract props to separate `type`s for easier visibility

More rules can be found here: https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin/docs/rules