### PR TITLE
Make frontend work with non-root URL

### DIFF
--- a/website/public/manifest.json
+++ b/website/public/manifest.json
@@ -8,7 +8,7 @@
       "type": "image/x-icon"
     },
     {
-      "src": "/favicon.png",
+      "src": "favicon.png",
       "sizes": "180x180",
       "type": "image/png"
     }

--- a/website/src/displaySecret/Result.tsx
+++ b/website/src/displaySecret/Result.tsx
@@ -12,7 +12,7 @@ type ResultProps = {
 
 const Result = (props: ResultProps) => {
   const { uuid, password, prefix } = props;
-  const base = `${window.location.protocol}//${window.location.host}/#/${prefix}`;
+  const base = (process.env.PUBLIC_URL || `${window.location.protocol}//${window.location.host}`) + `/#/${prefix}`;
   const short = `${base}/${uuid}`;
   const full = `${short}/${password}`;
   const isCustomPassword = prefix === 'c' || prefix === 'd';

--- a/website/src/displaySecret/Result.tsx
+++ b/website/src/displaySecret/Result.tsx
@@ -12,7 +12,9 @@ type ResultProps = {
 
 const Result = (props: ResultProps) => {
   const { uuid, password, prefix } = props;
-  const base = (process.env.PUBLIC_URL || `${window.location.protocol}//${window.location.host}`) + `/#/${prefix}`;
+  const base =
+    (process.env.PUBLIC_URL ||
+      `${window.location.protocol}//${window.location.host}`) + `/#/${prefix}`;
   const short = `${base}/${uuid}`;
   const full = `${short}/${password}`;
   const isCustomPassword = prefix === 'c' || prefix === 'd';

--- a/website/src/i18n.tsx
+++ b/website/src/i18n.tsx
@@ -8,7 +8,7 @@ i18n
   .use(Backend)
   .init({
     backend: {
-      loadPath: '/locales/{{lng}}.json',
+      loadPath: process.env.PUBLIC_URL + '/locales/{{lng}}.json',
     },
 
     fallbackLng: 'en',

--- a/website/src/shared/Header.tsx
+++ b/website/src/shared/Header.tsx
@@ -1,13 +1,18 @@
 import { Navbar, NavbarBrand, NavItem, NavLink } from 'reactstrap';
 
+
 export const Header = () => {
+  const base = process.env.PUBLIC_URL || '';
+  const home = base + '/';
+  const upload = base + '/#/upload';
+
   return (
     <Navbar color="dark" dark={true} expand="md">
-      <NavbarBrand href="/">
+      <NavbarBrand href={home}>
         Yopass <img width="40" height="40" alt="" src="yopass.svg" />
       </NavbarBrand>
       <NavItem>
-        <NavLink href="/#/upload">Upload</NavLink>
+        <NavLink href={upload}>Upload</NavLink>
       </NavItem>
     </Navbar>
   );

--- a/website/src/shared/Header.tsx
+++ b/website/src/shared/Header.tsx
@@ -1,6 +1,5 @@
 import { Navbar, NavbarBrand, NavItem, NavLink } from 'reactstrap';
 
-
 export const Header = () => {
   const base = process.env.PUBLIC_URL || '';
   const home = base + '/';


### PR DESCRIPTION
When using a subdirectory as `PUBLIC_URL`, e.g. https://example.com/yopass, some URLs were not working:

- translations and the favicon were not loaded because they used `/` as base URL
- result links were assuming `scheme://host/` as base URL
- links in header used `/` as base URL

With this PR, the environment variable PUBLIC_URL is respected in all these places if set. If not, fall back on previous behavior