### PR TITLE
Take "one time" checkbox into account for text secrets

### DIFF
--- a/website/src/createSecret/CreateSecret.tsx
+++ b/website/src/createSecret/CreateSecret.tsx
@@ -42,7 +42,7 @@ const CreateSecret = () => {
       const { data, status } = await postSecret({
         expiration: parseInt(form.lifetime),
         message: await encryptMessage(form.secret, pw),
-        one_time: true,
+        one_time: form.onetime,
       });
 
       if (status !== 200) {


### PR DESCRIPTION
Currently, all text secrets are only accessible once, the checkbox has only effect for uploads