### PR TITLE
Reflect consolidated secret URL paths in CLI

### DIFF
--- a/pkg/yopass/yopass.go
+++ b/pkg/yopass/yopass.go
@@ -134,19 +134,16 @@ func GenerateKey() (string, error) {
 }
 
 // SecretURL returns a URL which decryts the specified secret in the browser.
-func SecretURL(url, id, key string, fileOpt, keyOpt bool) string {
-	var path string
-	switch {
-	case !fileOpt && !keyOpt:
-		path = fmt.Sprintf("s/%s/%s", id, key)
-	case !fileOpt && keyOpt:
-		path = fmt.Sprintf("c/%s", id)
-	case fileOpt && !keyOpt:
-		path = fmt.Sprintf("f/%s/%s", id, key)
-	case fileOpt && keyOpt:
-		path = fmt.Sprintf("d/%s", id)
+func SecretURL(url, id, key string, fileOpt, manualKeyOpt bool) string {
+	prefix := "s"
+	if fileOpt {
+		prefix = "f"
 	}
-	return fmt.Sprintf("%s/#/%s", strings.TrimSuffix(url, "/"), path)
+	path := id
+	if !manualKeyOpt {
+		path += "/" + key
+	}
+	return fmt.Sprintf("%s/#/%s/%s", strings.TrimSuffix(url, "/"), prefix, path)
 }
 
 // ParseURL returns secret ID and key from a regular yopass URL.

--- a/pkg/yopass/yopass_test.go
+++ b/pkg/yopass/yopass_test.go
@@ -219,7 +219,7 @@ func TestSecretURL(t *testing.T) {
 			id:   "6cb3b277-dadd-47c5-b118-d49824b40e15",
 			key:  "manual-key",
 			kOpt: true,
-			want: "https://yopass.se/#/c/6cb3b277-dadd-47c5-b118-d49824b40e15",
+			want: "https://yopass.se/#/s/6cb3b277-dadd-47c5-b118-d49824b40e15",
 		},
 		{
 			name: "file upload",
@@ -236,7 +236,7 @@ func TestSecretURL(t *testing.T) {
 			key:  "manual-key",
 			fOpt: true,
 			kOpt: true,
-			want: "https://yopass.se/#/d/7a43c54c-6dad-4f98-b422-589021d1ac87",
+			want: "https://yopass.se/#/f/7a43c54c-6dad-4f98-b422-589021d1ac87",
 		},
 	}
 


### PR DESCRIPTION
The UI consolidated the different paths (#798) used to describe secrets.
This change reflects this change in the CLI to ensure it returns valid
URLs.

Fixes #799.