### PR TITLE
Use local Roboto font

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",
+    "@fontsource/roboto": "^4.5.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -34,10 +34,6 @@
       href="%PUBLIC_URL%/safari-pinned-tab.svg"
       color="#5bbad5"
     />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
-    />
     <title>Yopass: Share Secrets Securely</title>
   </head>
   <body style="margin: 0">

--- a/website/src/index.tsx
+++ b/website/src/index.tsx
@@ -2,6 +2,10 @@ import ReactDOM from 'react-dom';
 import { Suspense } from 'react';
 import App from './App';
 import './i18n';
+import '@fontsource/roboto/300.css';
+import '@fontsource/roboto/400.css';
+import '@fontsource/roboto/500.css';
+import '@fontsource/roboto/700.css';
 
 ReactDOM.render(
   <Suspense fallback={<div>Loading...</div>}>

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1996,6 +1996,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fontsource/roboto@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.5.1.tgz#63f7b783f755d8f6727eb60198627e7e1be3ac20"
+  integrity sha512-3mhfL+eNPG/woMNqwD/OHaW5qMpeGEBsDwzmhFmjB1yUV+M+M9P0NhP/AyHvnGz3DrqkvZ7CPzNMa+UkVLeELg==
+
 "@fortawesome/fontawesome-common-types@^0.2.36":
   version "0.2.36"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"


### PR DESCRIPTION
In order to avoid external calls from YoPass we now embed the roboto font using the [`@fontsource/roboto`](https://fontsource.org/fonts/roboto) package.
This should resolve https://github.com/jhaals/yopass/issues/960.