### PR TITLE
Log request using zap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.9.0
+	github.com/stretchr/testify v1.7.0
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.1

--- a/pkg/server/logging.go
+++ b/pkg/server/logging.go
@@ -45,7 +45,7 @@ func httpLogFormatter(logger *zap.Logger) func(io.Writer, handlers.LogFormatterP
 			zap.Time("timestamp", params.TimeStamp),
 			zap.String("method", req.Method),
 			zap.String("uri", uri),
-			zap.String("path", req.Proto),
+			zap.String("protocol", req.Proto),
 			zap.Int("responseStatus", params.StatusCode),
 			zap.Int("responseSize", params.Size),
 		)

--- a/pkg/server/logging.go
+++ b/pkg/server/logging.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"github.com/gorilla/handlers"
+	"go.uber.org/zap"
+	"io"
+	"net"
+)
+
+func httpLogFormatter(logger *zap.Logger) func(io.Writer, handlers.LogFormatterParams) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return func(_ io.Writer, params handlers.LogFormatterParams) {
+		var req = params.Request
+
+		username := "-"
+		if params.URL.User != nil {
+			if name := params.URL.User.Username(); name != "" {
+				username = name
+			}
+		}
+
+		host, _, err := net.SplitHostPort(req.RemoteAddr)
+		if err != nil {
+			host = req.RemoteAddr
+		}
+
+		uri := req.RequestURI
+
+		// Requests using the CONNECT method over HTTP/2.0 must use
+		// the authority field (aka r.Host) to identify the target.
+		// Refer: https://httpwg.github.io/specs/rfc7540.html#CONNECT
+		if req.ProtoMajor == 2 && req.Method == "CONNECT" {
+			uri = req.Host
+		}
+		if uri == "" {
+			uri = params.URL.RequestURI()
+		}
+
+		logger.Info(
+			"Request handled",
+			zap.String("host", host),
+			zap.String("username", username),
+			zap.Time("timestamp", params.TimeStamp),
+			zap.String("method", req.Method),
+			zap.String("uri", uri),
+			zap.String("path", req.Proto),
+			zap.Int("responseStatus", params.StatusCode),
+			zap.Int("responseSize", params.Size),
+		)
+	}
+}

--- a/pkg/server/logging.go
+++ b/pkg/server/logging.go
@@ -14,6 +14,13 @@ func httpLogFormatter(logger *zap.Logger) func(io.Writer, handlers.LogFormatterP
 
 	return func(_ io.Writer, params handlers.LogFormatterParams) {
 		var req = params.Request
+		if req == nil {
+			logger.Error(
+				"Unable to log request handled because no request exists",
+				zap.Reflect("LogFormatterParams", params),
+			)
+			return
+		}
 
 		host, _, err := net.SplitHostPort(req.RemoteAddr)
 		if err != nil {

--- a/pkg/server/logging.go
+++ b/pkg/server/logging.go
@@ -15,13 +15,6 @@ func httpLogFormatter(logger *zap.Logger) func(io.Writer, handlers.LogFormatterP
 	return func(_ io.Writer, params handlers.LogFormatterParams) {
 		var req = params.Request
 
-		username := "-"
-		if params.URL.User != nil {
-			if name := params.URL.User.Username(); name != "" {
-				username = name
-			}
-		}
-
 		host, _, err := net.SplitHostPort(req.RemoteAddr)
 		if err != nil {
 			host = req.RemoteAddr
@@ -42,7 +35,6 @@ func httpLogFormatter(logger *zap.Logger) func(io.Writer, handlers.LogFormatterP
 		logger.Info(
 			"Request handled",
 			zap.String("host", host),
-			zap.String("username", username),
 			zap.Time("timestamp", params.TimeStamp),
 			zap.String("method", req.Method),
 			zap.String("uri", uri),

--- a/pkg/server/logging_test.go
+++ b/pkg/server/logging_test.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"net"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/handlers"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestHTTPLogFormatter(t *testing.T) {
+	t.Run("Log request", func(t *testing.T) {
+		ts := time.Now()
+		request := httptest.NewRequest("GET", "https://yopass.se/", nil)
+		host, _, _ := net.SplitHostPort(request.RemoteAddr)
+
+		loggerCore, logs := observer.New(zap.DebugLevel)
+		logger := zap.New(loggerCore)
+
+		formatter := httpLogFormatter(logger)
+		formatter(nil, handlers.LogFormatterParams{
+			Request:    request,
+			TimeStamp:  ts,
+			StatusCode: 200,
+			Size:       50,
+		})
+
+		if logs.Len() != 1 {
+			t.Fatalf("Expected 1 log entry got %d", logs.Len())
+		}
+		infoLogs := logs.FilterLevelExact(zap.InfoLevel).All()
+		if len(infoLogs) != 1 {
+			t.Fatalf("Expected 1 info level log but got %d", len(infoLogs))
+		}
+
+		for _, f := range infoLogs[0].Context {
+			switch f.Key {
+			case "host":
+				assert.Equal(t, host, f.String)
+			case "timestamp":
+				assert.Equal(t, ts.UnixNano(), f.Integer)
+			case "method":
+				assert.Equal(t, "GET", f.String)
+			case "uri":
+				assert.Equal(t, "https://yopass.se/", f.String)
+			case "protocol":
+				assert.Equal(t, "HTTP/1.1", f.String)
+			case "responseStatus":
+				assert.Equal(t, int64(200), f.Integer)
+			case "responseSize":
+				assert.Equal(t, int64(50), f.Integer)
+			default:
+				t.Fatalf("Unexpected fields %s", f.Key)
+			}
+		}
+	})
+
+	t.Run("No request", func(t *testing.T) {
+		loggerCore, logs := observer.New(zap.DebugLevel)
+		logger := zap.New(loggerCore)
+
+		formatter := httpLogFormatter(logger)
+		formatter(nil, handlers.LogFormatterParams{})
+
+		if err := logger.Sync(); err != nil {
+			t.Fatalf("Unexpected error from logger.Sync %v", err)
+		}
+
+		if logs.Len() != 1 {
+			t.Fatalf("Expected 1 log entry got %d", logs.Len())
+		}
+		errorLogs := logs.FilterLevelExact(zap.ErrorLevel).All()
+		if len(errorLogs) != 1 {
+			t.Fatalf("Expected 1 error level because no request was provided but got %d", len(errorLogs))
+		}
+	})
+}

--- a/pkg/server/logging_test.go
+++ b/pkg/server/logging_test.go
@@ -37,7 +37,8 @@ func TestHTTPLogFormatter(t *testing.T) {
 			t.Fatalf("Expected 1 info level log but got %d", len(infoLogs))
 		}
 
-		for _, f := range infoLogs[0].Context {
+		fields := infoLogs[0].Context
+		for _, f := range fields {
 			switch f.Key {
 			case "host":
 				assert.Equal(t, host, f.String)
@@ -56,6 +57,10 @@ func TestHTTPLogFormatter(t *testing.T) {
 			default:
 				t.Fatalf("Unexpected fields %s", f.Key)
 			}
+		}
+
+		if len(fields) != 7 {
+			t.Fatalf("Expected 7 fields but got %d", len(fields))
 		}
 	})
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,12 +3,11 @@ package server
 import (
 	"encoding/json"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
 
-	uuid "github.com/gofrs/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/jhaals/yopass/pkg/yopass"
@@ -159,7 +158,7 @@ func (y *Server) HTTPHandler() http.Handler {
 	mx.HandleFunc("/file/"+keyParameter, y.optionsSecret).Methods(http.MethodOptions)
 
 	mx.PathPrefix("/").Handler(http.FileServer(http.Dir("public")))
-	return handlers.LoggingHandler(os.Stdout, SecurityHeadersHandler(mx))
+	return handlers.CustomLoggingHandler(nil, SecurityHeadersHandler(mx), httpLogFormatter(y.logger))
 }
 
 const keyParameter = "{key:(?:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})}"


### PR DESCRIPTION
Good morning/evening/afternoon,

This PR add a custom LogFormatter to allow the request logs to log using zap instead of stdOut. \
This ensures that all logs are in the same format allows for better and easier parting by log aggregators.

This continues https://github.com/jhaals/yopass/pull/1082 and the log context is based on https://github.com/gorilla/handlers/blob/master/logging.go#L169-L185 to ensure that the same information is available.

Logs before:
```
10.10.0.107 - - [12/Nov/2021:09:36:09 +0000] "GET /locales/en.json HTTP/1.1" 200 4520
10.10.0.56 - - [12/Nov/2021:09:36:09 +0000] "GET /locales/en-US.json HTTP/1.1" 404 19
10.10.0.42 - - [12/Nov/2021:09:36:09 +0000] "GET /secret/3dba449f-3726-4255-9cea-d9b76f9831f2 HTTP/1.1" 200 243
```

After:
```json
{"level":"info","ts":1636712967.8815591,"caller":"server/logging.go:42","msg":"Request is handled","host":"127.0.0.1","username":"-","timestamp":1636712967.8807414,"method":"POST","uri":"/secret","path":"HTTP/1.1","responseStatus":200,"responseSize":50}
{"level":"info","ts":1636712972.5601518,"caller":"server/logging.go:42","msg":"Request is handled","host":"127.0.0.1","username":"-","timestamp":1636712972.5597835,"method":"GET","uri":"/secret/1c71469a-f99e-45bf-84d3-eace8a060bc2","path":"HTTP/1.1","responseStatus":200,"responseSize":259}
```