### PR TITLE
Proper display multiline secrets

### DIFF
--- a/website/src/displaySecret/Secret.tsx
+++ b/website/src/displaySecret/Secret.tsx
@@ -32,6 +32,7 @@ const RenderSecret = ({ secret }: { readonly secret: string }) => {
           borderRadius: '4px',
           wordWrap: 'break-word',
           wordBreak: 'break-all',
+          whiteSpace: 'pre-line',
           fontFamily: 'monospace, monospace', // https://github.com/necolas/normalize.css/issues/519#issuecomment-197131966
         }}
       >


### PR DESCRIPTION
When sending secret:
```
a=b
b=c
```
Yopass shows decoded text as `a=b b=c`. Using copy button text is properly pasted.