### PR TITLE
feat(translations): add spanish translation url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,4 @@ Yopass has third party support for other languages. That means you can write tra
 Here's a list of available translations:
 - [German](https://github.com/Anturix/yopass-german)
 - [French](https://github.com/NicolasStr/yopass-french)
+- [Spanish](https://github.com/nbensa/yopass-spanish)


### PR DESCRIPTION
I made a Spanish translation.

This pull request only adds the url to my github repo to the README.md