### PR TITLE
fix: add data: to font-src CSP

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -179,7 +179,7 @@ func validExpiration(expiration int32) bool {
 func SecurityHeadersHandler(next http.Handler) http.Handler {
 	csp := []string{
 		"default-src 'self'",
-		"font-src 'self'",
+		"font-src 'self' data:",
 		"form-action 'self'",
 		"frame-ancestors 'none'",
 		"script-src 'self'",

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -338,7 +338,7 @@ func TestSecurityHeaders(t *testing.T) {
 		{
 			scheme: "http",
 			headers: map[string]string{
-				"content-security-policy": "default-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'",
+				"content-security-policy": "default-src 'self'; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'",
 				"referrer-policy":         "no-referrer",
 				"x-content-type-options":  "nosniff",
 				"x-frame-options":         "DENY",
@@ -349,7 +349,7 @@ func TestSecurityHeaders(t *testing.T) {
 		{
 			scheme: "https",
 			headers: map[string]string{
-				"content-security-policy":   "default-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'",
+				"content-security-policy":   "default-src 'self'; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'",
 				"referrer-policy":           "no-referrer",
 				"strict-transport-security": "max-age=31536000",
 				"x-content-type-options":    "nosniff",


### PR DESCRIPTION
Fixes #1920

As stated in https://github.com/jhaals/yopass/issues/1920, the CSP header for `font-src` needs to include `data:` scheme in order to support current frontend css fonts.