### PR TITLE
Use al2.provided lambda runtime, go1.x is soon EOL

### DIFF
--- a/deploy/aws-lambda/deploy.sh
+++ b/deploy/aws-lambda/deploy.sh
@@ -2,7 +2,7 @@
 set -ex 
 
 echo 'building yopass'
-GOOS=linux go build -o main
+GOOS=linux go build -o bootstrap main.go
 
 npx serverless deploy
 

--- a/deploy/aws-lambda/serverless.yml
+++ b/deploy/aws-lambda/serverless.yml
@@ -1,17 +1,19 @@
 service: yopass
 provider:
+  stage: dev
   name: aws
-  runtime: go1.x
+  runtime: provided.al2
   memorySize: 128
   region: eu-west-1
-  usagePlan:
-    quota:
-      limit: 1000
-      offset: 0
-      period: DAY
-    throttle:
-      burstLimit: 25
-      rateLimit: 50
+  apiGateway:
+    usagePlan:
+      quota:
+        limit: 1000
+        offset: 0
+        period: DAY
+      throttle:
+        burstLimit: 25
+        rateLimit: 50
   environment:
     TABLE_NAME: yopass-${opt:stage, self:provider.stage}
     MAX_LENGTH: 10000
@@ -30,11 +32,11 @@ package:
   exclude:
     - ./**
   include:
-    - ./main
+    - ./bootstrap
 
 functions:
   create:
-    handler: main
+    handler: bootstrap
     events:
       - http:
           method: any


### PR DESCRIPTION
Make changes to the AWS lambda deploy method to support the latest `al2.provided` runtime, and move away from the `go1.x` runtime which is being EOL'd December 31, 2023 (see [here](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/))

deploy.sh:

* Change the compiled executable name to `bootstrap` as required by the runtime

serverless.yml:
* Update the runtime
* References to `main` are now `bootstrap`
* Some small cleanup on the `usagePlan` section, which is now a subsection of `apiGateway` in most recent serverless config schema
* Add default `dev` stage

I'm currently using these changes to successfully deploy yopass as an AWS lambda.