### PR TITLE
Feature: env var config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The following options are currently available to install the CLI locally.
 
 Here are the server configuration options.
 
-Command line flags:
+### Command line flags
 
 ```console
 $ yopass-server -h
@@ -102,6 +102,22 @@ $ yopass-server -h
 ```
 
 Encrypted secrets can be stored either in Memcached or Redis by changing the `--database` flag.
+
+### Environment variables
+
+```console
+YOPASS_ADDRESS # listen address (default 0.0.0.0)
+YOPASS_DATABASE # database backend ('memcached' or 'redis') (default "memcached")
+YOPASS_MAX_LENGTH # max length of encrypted secret (default 10000)
+YOPASS_MEMCACHED # Memcached address (default "localhost:11211")
+YOPASS_METRICS_PORT # metrics server listen port (default -1)
+YOPASS_PORT # listen port (default 1337)
+YOPASS_REDIS # Redis URL (default "redis://localhost:6379/0")
+YOPASS_TLS_CERT # path to TLS certificate
+YOPASS_TLS_KEY # path to TLS key
+```
+
+see [docker compose example](deploy/docker-compose/env-config/docker-compose.yml)
 
 ### Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -184,3 +184,4 @@ Here's a list of available translations:
 - [Spanish](https://github.com/nbensa/yopass-spanish)
 - [Polish](https://github.com/mdurajewski/yopass-polish)
 - [Dutch](https://github.com/KevinRosendaal/yopass-dutch)
+- [Russian](https://github.com/karpechenkovkonstantin/yopass-russian)

--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -32,6 +32,7 @@ func init() {
 	pflag.Bool("force-onetime-secrets", false, "reject non onetime secrets from being created")
 	pflag.CommandLine.AddGoFlag(&flag.Flag{Name: "log-level", Usage: "Log level", Value: &logLevel})
 
+	viper.SetEnvPrefix("yopass")
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	_ = viper.BindPFlags(pflag.CommandLine)

--- a/deploy/docker-compose/env-config/docker-compose.yml
+++ b/deploy/docker-compose/env-config/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.0"
+
+services:
+  memcached:
+    image: memcached
+    restart: always
+    expose:
+      - "11211"
+
+  yopass:
+    image: jhaals/yopass
+    restart: always
+    ports:
+      - "127.0.0.1:80:80"
+      - "127.0.0.1:9090:9090"
+    environment:
+      # listen address (default 0.0.0.0)
+      # - YOPASS_ADDRESS
+      # listen port (default 1337)
+      - YOPASS_PORT=80
+      # metrics server listen port (default -1)
+      - YOPASS_METRICS_PORT=9090
+      # max length of encrypted secret (default 10000)
+      - YOPASS_MAX_LENGTH=100000
+      # database backend ('memcached' or 'redis') (default "memcached")
+      - YOPASS_DATABASE=memcached
+      # Memcached address (default "localhost:11211")
+      - YOPASS_MEMCACHED=localhost:11211
+      # Redis URL (default "redis://localhost:6379/0")
+      # - YOPASS_REDIS=redis://localhost:6379/0
+      # path to TLS certificate
+      # - YOPASS_TLS_CERT
+      # path to TLS key
+      # - YOPASS_TLS_KEY


### PR DESCRIPTION
This PR adds:
- a prefix (`yopass`) to config variables loaded from env. this might be considered a non breaking change, since it was an undocumented feature before.
- a docker compose example for configuring yopass using env vars
- documentation for configuring yopass using env vars to README

closes #2122 