### PR TITLE
Prevent automatic browser translation of the secret string

### DIFF
--- a/next/src/components/Secret.tsx
+++ b/next/src/components/Secret.tsx
@@ -27,6 +27,7 @@ const RenderSecret = ({ secret }: { readonly secret: string }) => {
       <Typography
         id="pre"
         data-test-id="preformatted-text-secret"
+        translate="no"
         sx={{
           backgroundColor: '#ecf0f1',
           padding: '15px',


### PR DESCRIPTION
Hello,
I had an issue with users that have automatic browser translation of the web pages of their browser enabled where the secret password i sent them was translated, or at least partially translated (I often use english word combination as easy to memorize passwords).

Exemple with Chrome 129.0.6668.60 automatic english -> french translation
![image](https://github.com/user-attachments/assets/b6cdc446-2a48-494e-bb52-a8b8f3d41a29)


This pull request is to add the `translation="no"` flag on the secret field.