### PR TITLE
Add headless mode to yopass-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ $ yopass-server -h
       --redis string       Redis URL (default "redis://localhost:6379/0")
       --tls-cert string    path to TLS certificate
       --tls-key string     path to TLS key
+      --headless           only run the server and not the UI (default false)
 ```
 
 Encrypted secrets can be stored either in Memcached or Redis by changing the `--database` flag.

--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -36,6 +36,7 @@ func init() {
 	pflag.String("tls-cert", "", "path to TLS certificate")
 	pflag.String("tls-key", "", "path to TLS key")
 	pflag.Bool("force-onetime-secrets", false, "reject non onetime secrets from being created")
+	pflag.Bool("headless", false, "only run the server and not the UI (default false)")
 	pflag.CommandLine.AddGoFlag(&flag.Flag{Name: "log-level", Usage: "Log level", Value: &logLevel})
 
 	viper.AutomaticEnv()
@@ -74,7 +75,7 @@ func main() {
 	key := viper.GetString("tls-key")
 	quit := make(chan os.Signal, 1)
 
-	y := server.New(db, viper.GetInt("max-length"), registry, viper.GetBool("force-onetime-secrets"), logger)
+	y := server.New(db, viper.GetInt("max-length"), registry, viper.GetBool("force-onetime-secrets"), logger, viper.GetBool("headless"))
 	yopassSrv := &http.Server{
 		Addr:      fmt.Sprintf("%s:%d", viper.GetString("address"), viper.GetInt("port")),
 		Handler:   y.HTTPHandler(),

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -104,7 +104,7 @@ func TestCreateSecret(t *testing.T) {
 		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
 			req, _ := http.NewRequest("POST", "/secret", tc.body)
 			rr := httptest.NewRecorder()
-			y := New(tc.db, tc.maxLength, prometheus.NewRegistry(), false, zaptest.NewLogger(t))
+			y := New(tc.db, tc.maxLength, prometheus.NewRegistry(), false, zaptest.NewLogger(t), false)
 			y.createSecret(rr, req)
 			var s yopass.Secret
 			json.Unmarshal(rr.Body.Bytes(), &s)
@@ -161,7 +161,7 @@ func TestOneTimeEnforcement(t *testing.T) {
 		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
 			req, _ := http.NewRequest("POST", "/secret", tc.body)
 			rr := httptest.NewRecorder()
-			y := New(&mockDB{}, 100, prometheus.NewRegistry(), tc.requireOneTime, zaptest.NewLogger(t))
+			y := New(&mockDB{}, 100, prometheus.NewRegistry(), tc.requireOneTime, zaptest.NewLogger(t), false)
 			y.createSecret(rr, req)
 			var s yopass.Secret
 			json.Unmarshal(rr.Body.Bytes(), &s)
@@ -205,7 +205,7 @@ func TestGetSecret(t *testing.T) {
 				t.Fatal(err)
 			}
 			rr := httptest.NewRecorder()
-			y := New(tc.db, 1, prometheus.NewRegistry(), false, zaptest.NewLogger(t))
+			y := New(tc.db, 1, prometheus.NewRegistry(), false, zaptest.NewLogger(t), false)
 			y.getSecret(rr, req)
 			cacheControl := rr.Header().Get("Cache-Control")
 			if cacheControl != "private, no-cache" {
@@ -256,7 +256,7 @@ func TestDeleteSecret(t *testing.T) {
 				t.Fatal(err)
 			}
 			rr := httptest.NewRecorder()
-			y := New(tc.db, 1, prometheus.NewRegistry(), false, zaptest.NewLogger(t))
+			y := New(tc.db, 1, prometheus.NewRegistry(), false, zaptest.NewLogger(t), false)
 			y.deleteSecret(rr, req)
 			var s struct {
 				Message string `json:"message"`
@@ -286,7 +286,7 @@ func TestMetrics(t *testing.T) {
 			path:   "/secret/invalid-key-format",
 		},
 	}
-	y := New(&mockDB{}, 1, prometheus.NewRegistry(), false, zaptest.NewLogger(t))
+	y := New(&mockDB{}, 1, prometheus.NewRegistry(), false, zaptest.NewLogger(t), false)
 	h := y.HTTPHandler()
 
 	for _, r := range requests {
@@ -359,7 +359,7 @@ func TestSecurityHeaders(t *testing.T) {
 		},
 	}
 
-	y := New(&mockDB{}, 1, prometheus.NewRegistry(), false, zaptest.NewLogger(t))
+	y := New(&mockDB{}, 1, prometheus.NewRegistry(), false, zaptest.NewLogger(t), false)
 	h := y.HTTPHandler()
 
 	t.Parallel()

--- a/pkg/yopass/client_test.go
+++ b/pkg/yopass/client_test.go
@@ -3,9 +3,10 @@ package yopass_test
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/zap/zaptest"
 	"net/http/httptest"
 	"testing"
+
+	"go.uber.org/zap/zaptest"
 
 	"github.com/jhaals/yopass/pkg/server"
 	"github.com/jhaals/yopass/pkg/yopass"
@@ -14,7 +15,7 @@ import (
 
 func TestFetch(t *testing.T) {
 	db := testDB(map[string]string{})
-	y := server.New(&db, 1024, prometheus.NewRegistry(), false, zaptest.NewLogger(t))
+	y := server.New(&db, 1024, prometheus.NewRegistry(), false, zaptest.NewLogger(t), false)
 	ts := httptest.NewServer(y.HTTPHandler())
 	defer ts.Close()
 
@@ -46,7 +47,7 @@ func TestFetchInvalidServer(t *testing.T) {
 }
 func TestStore(t *testing.T) {
 	db := testDB(map[string]string{})
-	y := server.New(&db, 1024, prometheus.NewRegistry(), false, zaptest.NewLogger(t))
+	y := server.New(&db, 1024, prometheus.NewRegistry(), false, zaptest.NewLogger(t), false)
 	ts := httptest.NewServer(y.HTTPHandler())
 	defer ts.Close()
 


### PR DESCRIPTION
Adding headless mode as a flag for yopass-server by removing the UI route from the yopass-server HTTP server if flag is set.

This will provide the possibility to be running the yopass-server and having a custom UI to use the server, without having the Yopass UI showing on the API root.