### PR TITLE
Add build-time support for customizable default API and URL endpoints

### DIFF
--- a/cmd/yopass/main.go
+++ b/cmd/yopass/main.go
@@ -43,7 +43,7 @@ var (
 )
 
 func init() {
-    // Use build-time values if set; otherwise, fall back to hardcoded defaults. 
+	// Use build-time values if set; otherwise, fall back to hardcoded defaults.
 	// Build with -ldflags "-X main.defaultAPI=https://your-custom-api.com -X main.defaultURL=https://your-custom-url.com" to override defaults
 	viper.SetDefault("api", defaultAPI)
 	viper.SetDefault("url", defaultURL)

--- a/cmd/yopass/main.go
+++ b/cmd/yopass/main.go
@@ -37,10 +37,16 @@ Examples:
 Website: %s
 `
 
+var (
+	defaultAPI = "https://api.yopass.se"
+	defaultURL = "https://yopass.se"
+)
+
 func init() {
-	// Defaults
-	viper.SetDefault("api", "https://api.yopass.se")
-	viper.SetDefault("url", "https://yopass.se")
+    // Use build-time values if set; otherwise, fall back to hardcoded defaults. 
+	// Build with -ldflags "-X main.defaultAPI=https://your-custom-api.com -X main.defaultURL=https://your-custom-url.com" to override defaults
+	viper.SetDefault("api", defaultAPI)
+	viper.SetDefault("url", defaultURL)
 	viper.SetDefault("one-time", true)
 	viper.SetDefault("expiration", "1h")
 


### PR DESCRIPTION
**Description:**
This update allows the use of build-time values to customize the default API and URL endpoints.

**Usage:**
You can override the default endpoints during the build process by using the following -ldflags options during `go build`:
```
-ldflags "-X main.defaultAPI=https://your-custom-api.com -X main.defaultURL=https://your-custom-url.com"
```
