### PR TITLE
Allow configuration of asset path.

### DIFF
--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -30,6 +30,7 @@ func init() {
 	pflag.String("address", "", "listen address (default 0.0.0.0)")
 	pflag.Int("port", 1337, "listen port")
 	pflag.String("database", "memcached", "database backend ('memcached' or 'redis')")
+	pflag.String("asset-path", "public", "path to the assets folder")
 	pflag.Int("max-length", 10000, "max length of encrypted secret")
 	pflag.String("memcached", "localhost:11211", "memcached address")
 	pflag.Int("metrics-port", -1, "metrics server listen port")
@@ -65,6 +66,7 @@ func main() {
 		MaxLength:           viper.GetInt("max-length"),
 		Registry:            registry,
 		ForceOneTimeSecrets: viper.GetBool("force-onetime-secrets"),
+		AssetPath:           viper.GetString("asset-path"),
 		Logger:              logger,
 	}
 	yopassSrv := &http.Server{
@@ -74,6 +76,7 @@ func main() {
 	}
 	go func() {
 		logger.Info("Starting yopass server", zap.String("address", yopassSrv.Addr))
+		logger.Info("Loading assets from: ", zap.String("asset-path", y.AssetPath))
 		err := listenAndServe(yopassSrv, cert, key)
 		if !errors.Is(err, http.ErrServerClosed) {
 			logger.Fatal("yopass stopped unexpectedly", zap.Error(err))

--- a/cmd/yopass/main_test.go
+++ b/cmd/yopass/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -270,7 +269,7 @@ func pingDemoServer() bool {
 }
 
 func tempFile(s string) (*os.File, error) {
-	f, err := ioutil.TempFile("", "yopass-")
+	f, err := os.CreateTemp("", "yopass-")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,7 @@ type Server struct {
 	MaxLength           int
 	Registry            *prometheus.Registry
 	ForceOneTimeSecrets bool
+	AssetPath           string
 	Logger              *zap.Logger
 }
 
@@ -162,7 +163,7 @@ func (y *Server) HTTPHandler() http.Handler {
 		mx.HandleFunc("/file/"+keyParameter, y.deleteSecret).Methods(http.MethodDelete)
 	}
 
-	mx.PathPrefix("/").Handler(http.FileServer(http.Dir("public")))
+	mx.PathPrefix("/").Handler(http.FileServer(http.Dir(y.AssetPath)))
 	return handlers.CustomLoggingHandler(nil, SecurityHeadersHandler(mx), httpLogFormatter(y.Logger))
 }
 


### PR DESCRIPTION
This PR allows to override the default configuration of the asset path which is `public` by default.

If no value is set, this defaults to `public` and does not change existing behavior and will preserve backward compatibility.
- While here also replace the deprecated `ioutil.TempFile()` with `os.CreateTemp()`.