### PR TITLE
feat: seperate decryption domains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,9 @@ COPY website/src /website/src
 COPY website/public /website/public
 
 ARG PUBLIC_URL
+ARG PUBLIC_DECRYPTION_URL
 ARG ROUTER_TYPE
-RUN PUBLIC_URL="${PUBLIC_URL}" ROUTER_TYPE="${ROUTER_TYPE}" yarn build
+RUN PUBLIC_URL="${PUBLIC_URL}" PUBLIC_DECRYPTION_URL="${PUBLIC_DECRYPTION_URL}" ROUTER_TYPE="${ROUTER_TYPE}" yarn build
 
 
 # Final minimal image including only built resources

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,33 @@
+# Yopass Server build stage
 FROM golang:bookworm AS app
-RUN mkdir -p /yopass
+
 WORKDIR /yopass
-COPY . .
+COPY go.mod go.sum LICENSE /yopass/
+COPY cmd /yopass/cmd
+COPY pkg /yopass/pkg
+
 RUN go build ./cmd/yopass && go build ./cmd/yopass-server
 
-FROM node:22 AS website
-COPY website /website
-WORKDIR /website
-RUN yarn install --network-timeout 600000 && yarn build
 
+# Website build stage
+FROM node:22 AS website
+WORKDIR /website
+
+# Install dependencies
+COPY website/package.json website/yarn.lock /website/
+RUN yarn install --network-timeout 600000
+
+# Build and bundle src
+COPY website/tsconfig.json website/vite.config.ts website/index.html /website/
+COPY website/src /website/src
+COPY website/public /website/public
+
+ARG PUBLIC_URL
+ARG ROUTER_TYPE
+RUN PUBLIC_URL="${PUBLIC_URL}" ROUTER_TYPE="${ROUTER_TYPE}" yarn build
+
+
+# Final minimal image including only built resources
 FROM gcr.io/distroless/base
 COPY --from=app /yopass/yopass /yopass/yopass-server /
 COPY --from=website /website/build /public

--- a/website/README.md
+++ b/website/README.md
@@ -18,6 +18,15 @@ PUBLIC_URL='https://my-domain.com' REACT_APP_BACKEND_URL='http://api.my-domain.c
 
 Upload contents of `build/` to your CDN or hosting provider of choice, be it S3, Netlify or GCS.
 
+## Seperate Domains for encryption/decryption
+
+Note that this does only change the frontend-url presented for decryption!
+You need to block non-GET Requests to endpoints `/secret`, `/file` for yourself.
+
+```bash
+PUBLIC_URL='https://my-encryption-domain.internal' PUBLIC_DECRYPTION_URL='https://my-decryption-domain.com' yarn build
+```
+
 ## Multilingual Build
 
 The Yopass user interface is shipped in English by default. It is possible to create a custom build that supports multiple languages.

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -7,6 +7,23 @@ import { Features } from './shared/Features';
 import { Attribution } from './shared/Attribution';
 import { theme } from './theme';
 import { HashRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
+
+const Router = ({ children }: React.PropsWithChildren) => {
+  if (process.env.ROUTER_TYPE === 'history') {
+    return (
+      <BrowserRouter>
+        {children}
+      </BrowserRouter>
+    )
+  }
+
+  return (
+    <HashRouter>
+      {children}
+    </HashRouter>
+  )
+}
 
 const App = () => {
   // TODO: Removed in future version.
@@ -21,14 +38,14 @@ const App = () => {
   return (
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>
-        <HashRouter>
+        <Router>
           <Header />
           <Container maxWidth={'lg'}>
             <Routing />
             <Features />
             <Attribution />
           </Container>
-        </HashRouter>
+        </Router>
       </ThemeProvider>
     </StyledEngineProvider>
   );

--- a/website/src/displaySecret/Result.tsx
+++ b/website/src/displaySecret/Result.tsx
@@ -12,7 +12,7 @@ import {
   Box,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useAbsoluteRouteBase } from '../utils/useBase';
+import { useAbsoluteDecryptionRouteBase } from '../utils/useBase';
 
 type ResultProps = {
   readonly uuid: string;
@@ -22,7 +22,7 @@ type ResultProps = {
 };
 
 const Result = ({ uuid, password, prefix, customPassword }: ResultProps) => {
-  const base = useAbsoluteRouteBase() + `/${prefix}`;
+  const base = useAbsoluteDecryptionRouteBase() + `/${prefix}`;
   const short = `${base}/${uuid}`;
   const full = `${short}/${password}`;
   const { t } = useTranslation();

--- a/website/src/displaySecret/Result.tsx
+++ b/website/src/displaySecret/Result.tsx
@@ -12,6 +12,7 @@ import {
   Box,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { useAbsoluteRouteBase } from '../utils/useBase';
 
 type ResultProps = {
   readonly uuid: string;
@@ -21,9 +22,7 @@ type ResultProps = {
 };
 
 const Result = ({ uuid, password, prefix, customPassword }: ResultProps) => {
-  const base =
-    (process.env.PUBLIC_URL ||
-      `${window.location.protocol}//${window.location.host}`) + `/#/${prefix}`;
+  const base = useAbsoluteRouteBase() + `/${prefix}`;
   const short = `${base}/${uuid}`;
   const full = `${short}/${password}`;
   const { t } = useTranslation();

--- a/website/src/i18n.tsx
+++ b/website/src/i18n.tsx
@@ -2,6 +2,7 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import Backend from 'i18next-http-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import { useBaseUrl } from './utils/useBase';
 
 i18n
   .use(initReactI18next)
@@ -9,7 +10,7 @@ i18n
   .use(LanguageDetector)
   .init({
     backend: {
-      loadPath: process.env.PUBLIC_URL + '/locales/{{lng}}.json',
+      loadPath: useBaseUrl() + '/locales/{{lng}}.json',
     },
 
     fallbackLng: process.env.REACT_APP_FALLBACK_LANGUAGE || 'en',

--- a/website/src/shared/Header.tsx
+++ b/website/src/shared/Header.tsx
@@ -1,14 +1,15 @@
 import { AppBar, Toolbar, Typography, Button, Box, Link } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
+import { useAbsoluteRouteBase, useBaseUrl } from '../utils/useBase';
 
 export const Header = () => {
   const { t } = useTranslation();
   const location = useLocation();
   const isOnUploadPage = location.pathname.includes('upload');
-  const base = process.env.PUBLIC_URL || '';
-  const home = base + '/#/';
-  const upload = base + '/#/upload';
+  const base = useAbsoluteRouteBase();
+  const home = base + '/';
+  const upload = base + '/upload';
   return (
     <AppBar position="static" color="transparent" sx={{ marginBottom: 4 }}>
       <Toolbar>
@@ -25,7 +26,7 @@ export const Header = () => {
               component="img"
               height="40"
               alt=""
-              src="yopass.svg"
+              src={useBaseUrl() + '/yopass.svg'}
             />
           </Typography>
         </Link>

--- a/website/src/utils/useBase.ts
+++ b/website/src/utils/useBase.ts
@@ -3,6 +3,11 @@ export const useBaseUrl = function (): string {
       `${window.location.protocol}//${window.location.host}`);
 }
 
+export const useAbsoluteDecryptionRouteBase = function (): string {
+    const baseUrl = process.env.PUBLIC_DECRYPTION_URL || useBaseUrl();
+    return baseUrl + useRelativeRouteBase();
+}
+
 export const useAbsoluteRouteBase = function (): string {
     return useBaseUrl() + useRelativeRouteBase();
 }

--- a/website/src/utils/useBase.ts
+++ b/website/src/utils/useBase.ts
@@ -1,0 +1,12 @@
+export const useBaseUrl = function (): string {
+  return (process.env.PUBLIC_URL ||
+      `${window.location.protocol}//${window.location.host}`);
+}
+
+export const useAbsoluteRouteBase = function (): string {
+    return useBaseUrl() + useRelativeRouteBase();
+}
+
+export const useRelativeRouteBase = function (): string {
+  return process.env.ROUTER_TYPE === 'hash' ? '/#' : '';
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig(() => {
         CI: process.env.CI,
         NODE_ENV: process.env.NODE_ENV,
         PUBLIC_URL,
+        PUBLIC_DECRYPTION_URL: process.env.PUBLIC_DECRYPTION_URL,
         ROUTER_TYPE,
         REACT_APP_BACKEND_URL: process.env.REACT_APP_BACKEND_URL,
         REACT_APP_FALLBACK_LANGUAGE: process.env.REACT_APP_FALLBACK_LANGUAGE,

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -28,7 +28,6 @@ export default defineConfig(() => {
         NODE_ENV: process.env.NODE_ENV,
         PUBLIC_URL,
         ROUTER_TYPE,
-        ROUTER_API: process.env.ROUTER_API === 'history' ,
         REACT_APP_BACKEND_URL: process.env.REACT_APP_BACKEND_URL,
         REACT_APP_FALLBACK_LANGUAGE: process.env.REACT_APP_FALLBACK_LANGUAGE,
         START_SERVER_AND_TEST_INSECURE:

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -4,7 +4,10 @@ import react from '@vitejs/plugin-react';
 import { defineConfig, UserConfigExport } from 'vite';
 
 export default defineConfig(() => {
-  const PUBLIC_URL = process.env.PUBLIC_URL || '';
+  // Ensure PUBLIC_URL is not an empty string, otherwise vite base url is
+  // relative to currently accessed path instead of '/'
+  const PUBLIC_URL = process.env.PUBLIC_URL || undefined;
+  const ROUTER_TYPE = process.env.ROUTER_TYPE === 'history' ? 'history' : 'hash';
 
   const config: UserConfigExport = {
     plugins: [react()],
@@ -24,6 +27,8 @@ export default defineConfig(() => {
         CI: process.env.CI,
         NODE_ENV: process.env.NODE_ENV,
         PUBLIC_URL,
+        ROUTER_TYPE,
+        ROUTER_API: process.env.ROUTER_API === 'history' ,
         REACT_APP_BACKEND_URL: process.env.REACT_APP_BACKEND_URL,
         REACT_APP_FALLBACK_LANGUAGE: process.env.REACT_APP_FALLBACK_LANGUAGE,
         START_SERVER_AND_TEST_INSECURE:


### PR DESCRIPTION
# Purpose
In some scenarios you might have a different domain used for public decryption.

Hint: This Pull request is based on #2689 and is also related to #1635

# Implemented solution
New built-time env `PUBLIC_DECRYPTION_URL` is added to adjust the frontend-presented domain for decryption.