### PR TITLE
Add disable upload feature

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -130,6 +130,15 @@ func (y *Server) optionsSecret(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Access-Control-Allow-Headers", "content-type")
 }
 
+func (y *Server) configHandler(w http.ResponseWriter, r *http.Request) {
+    config := map[string]string{
+        "DISABLE_UPLOAD": viper.GetString("YOPASS_DISABLE_UPLOAD_FEATURE"),
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(config)
+}
+
 // HTTPHandler containing all routes
 func (y *Server) HTTPHandler() http.Handler {
 	mx := mux.NewRouter()

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -7,6 +7,7 @@ import { Features } from './shared/Features';
 import { Attribution } from './shared/Attribution';
 import { theme } from './theme';
 import { HashRouter } from 'react-router-dom';
+import { ConfigProvider } from './shared/ConfigContext';
 
 const App = () => {
   // TODO: Removed in future version.
@@ -23,12 +24,14 @@ const App = () => {
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>
         <HashRouter>
+        <ConfigProvider>
           <Header />
           <Container maxWidth={'lg'}>
             <Routing />
             {features && <Features />}
             <Attribution />
           </Container>
+          </ConfigProvider>
         </HashRouter>
       </ThemeProvider>
     </StyledEngineProvider>

--- a/website/src/Routing.tsx
+++ b/website/src/Routing.tsx
@@ -3,13 +3,15 @@ import { Route, Routes } from 'react-router-dom';
 import CreateSecret from './createSecret/CreateSecret';
 import DisplaySecret from './displaySecret/DisplaySecret';
 import Upload from './createSecret/Upload';
+import { useConfig } from './shared/ConfigContext';
 
 export const Routing = () => {
   const oneClickLink = process.env.YOPASS_DISABLE_ONE_CLICK_LINK !== '1';
+  const { DISABLE_UPLOAD } = useConfig();
   return (
     <Routes>
       <Route path="/" element={<CreateSecret />} />
-      <Route path="/upload" element={<Upload />} />
+      {!DISABLE_UPLOAD && <Route path="/upload" element={<Upload />} />}
       {oneClickLink && (
         <Route path="/:format/:key/:password" element={<DisplaySecret />} />
       )}

--- a/website/src/shared/ConfigContext.tsx
+++ b/website/src/shared/ConfigContext.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+interface Config {
+  DISABLE_UPLOAD: boolean;
+}
+
+const ConfigContext = createContext<Config | undefined>(undefined);
+
+export const ConfigProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [config, setConfig] = useState<Config>({ DISABLE_UPLOAD: false });
+
+  useEffect(() => {
+    fetch("/config")
+      .then((response) => response.json())
+      .then((data) => setConfig({ DISABLE_UPLOAD: data.DISABLE_UPLOAD === "true" }))
+      .catch((error) => console.error("Error loading config:", error));
+  }, []);
+
+  return <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>;
+};
+
+export const useConfig = () => {
+  const context = useContext(ConfigContext);
+  if (!context) {
+    throw new Error("useConfig must be used within a ConfigProvider");
+  }
+  return context;
+};

--- a/website/src/shared/Header.tsx
+++ b/website/src/shared/Header.tsx
@@ -1,10 +1,12 @@
 import { AppBar, Toolbar, Typography, Button, Box, Link } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
+import { useConfig } from './ConfigContext';
 
 export const Header = () => {
   const { t } = useTranslation();
   const location = useLocation();
+  const { DISABLE_UPLOAD } = useConfig();
   const isOnUploadPage = location.pathname.includes('upload');
   const base = process.env.PUBLIC_URL || '';
   const home = base + '/#/';
@@ -34,14 +36,11 @@ export const Header = () => {
             marginLeft: 'auto',
           }}
         >
-          <Button
-            component={Link}
-            href={isOnUploadPage ? home : upload}
-            variant="contained"
-            color="primary"
-          >
-            {isOnUploadPage ? t('header.buttonHome') : t('header.buttonUpload')}
-          </Button>
+          {!DISABLE_UPLOAD && (
+            <Button component={Link} href={isOnUploadPage ? home : upload} variant="contained" color="primary">
+              {isOnUploadPage ? t("header.buttonHome") : t("header.buttonUpload")}
+            </Button>
+          )}
         </Box>
       </Toolbar>
     </AppBar>


### PR DESCRIPTION
Hello, 
This pull request is about to allow users to disable the upload feature. 
In order to increase security of the platform for specific security contexts.

The feature works by introducing a ConfigHandler and ConfigContext to provide a route /config from the backend server to the frontend environment so that react can use it to hide the upload / home button.

The config is done via a viper string config (so it can be done via an env var) that's named "YOPASS_DISABLE_UPLOAD_FEATURE" that when set to 1, disables the upload features.

I hope that this feature will be welcomed.

Best regards.
