### PR TITLE
feat: add optional footer component with imprint and privacy notice links

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -47,3 +47,4 @@ PUBLIC_URL='https://my-domain.com' REACT_APP_BACKEND_URL='http://api.my-domain.c
 
 - `YOPASS_DISABLE_FEATURES_CARDS=1` - Allows disabling Features cards
 - `YOPASS_DISABLE_ONE_CLICK_LINK=1` - Allows disabling "One-click link" support
+- `YOPASS_SHOW_PRIVACY_NOTICE=1` - Allows showing a privacy notice in the footer

--- a/website/public/locales/en.json
+++ b/website/public/locales/en.json
@@ -91,5 +91,9 @@
   "header": {
     "buttonHome": "Home",
     "buttonUpload": "Upload"
+  },
+  "footer": {
+    "imprint": "Imprint",
+    "privacyNotice": "Privacy Notice"
   }
 }

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { Header } from './shared/Header';
 import { Routing } from './Routing';
 import { Features } from './shared/Features';
-import { Attribution } from './shared/Attribution';
+import { Footer } from './shared/Footer';
 import { theme } from './theme';
 import { HashRouter } from 'react-router-dom';
 import { ConfigProvider } from './shared/ConfigContext';
@@ -30,8 +30,8 @@ const App = () => {
             <Container maxWidth={'lg'}>
               <Routing />
               {features && <Features />}
-              <Attribution />
             </Container>
+            <Footer />
           </ConfigProvider>
         </HashRouter>
       </ThemeProvider>

--- a/website/src/shared/Attribution.tsx
+++ b/website/src/shared/Attribution.tsx
@@ -18,7 +18,6 @@ export const Attribution = () => {
   return (
     <Container>
       <Typography
-        margin={4}
         variant="body2"
         color="textSecondary"
         align="center"

--- a/website/src/shared/Footer.tsx
+++ b/website/src/shared/Footer.tsx
@@ -1,0 +1,33 @@
+import { Box, Container, Link } from '@mui/material';
+import { Attribution } from './Attribution';
+import { useTranslation } from 'react-i18next';
+
+export const Footer = () => {
+    const { t } = useTranslation();
+
+    const privacyNotice = process.env.YOPASS_SHOW_PRIVACY_NOTICE == '1';
+
+    return (
+        <Box
+            component="footer"
+            sx={{
+                py: 3,
+                px: 2,
+                mt: 'auto',
+                marginTop: 2,
+            }}
+        >
+            <Container maxWidth="md">
+                {privacyNotice && <Box display="flex" justifyContent="center" gap={3} mb={4}>
+                    <Link href="https://www.example.com/imprint/">
+                        {t('footer.imprint')}{' '}
+                    </Link>
+                    <Link href="https://www.example.com/privacy-notice/">
+                        {t('footer.privacyNotice')}{' '}
+                    </Link>
+                </Box>}
+                <Attribution />
+            </Container>
+        </Box>
+    );
+};

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -32,6 +32,8 @@ export default defineConfig(() => {
           process.env.YOPASS_DISABLE_FEATURES_CARDS,
         YOPASS_DISABLE_ONE_CLICK_LINK:
           process.env.YOPASS_DISABLE_ONE_CLICK_LINK,
+        YOPASS_SHOW_PRIVACY_NOTICE:
+          process.env.YOPASS_SHOW_PRIVACY_NOTICE,
       },
     },
     server: {


### PR DESCRIPTION
Adds an optional footer component with imprint and privacy notice links.

Usage: Set YOPASS_SHOW_PRIVACY_NOTICE=1 to display the footer.

Changes:
- New Footer component with configurable privacy links
- Added footer translations and environment variable support
- Restructured layout to place footer outside main container

Fixes #1529