### PR TITLE
Add 1 month as expiration value

### DIFF
--- a/cmd/yopass/main_test.go
+++ b/cmd/yopass/main_test.go
@@ -193,6 +193,10 @@ func TestExpiration(t *testing.T) {
 			604800,
 		},
 		{
+			"1m",
+			2592000,
+		},
+		{
 			"invalid",
 			0,
 		},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -170,9 +170,9 @@ func (y *Server) HTTPHandler() http.Handler {
 const keyParameter = "{key:(?:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})}"
 
 // validExpiration validates that expiration is either
-// 3600(1hour), 86400(1day) or 604800(1week)
+// 3600(1hour), 86400(1day), 604800(1week) or 2592000(1month).
 func validExpiration(expiration int32) bool {
-	for _, ttl := range []int32{3600, 86400, 604800} {
+	for _, ttl := range []int32{3600, 86400, 604800, 2592000} {
 		if ttl == expiration {
 			return true
 		}

--- a/website/public/locales/en.json
+++ b/website/public/locales/en.json
@@ -70,7 +70,8 @@
     "legend": "The encrypted message will be deleted automatically after",
     "optionOneHourLabel": "One hour",
     "optionOneDayLabel": "One day",
-    "optionOneWeekLabel": "One week"
+    "optionOneWeekLabel": "One week",
+    "optionOneMonthLabel": "One month"
   },
   "features": {
     "title": "Share secrets securely with ease",

--- a/website/src/shared/Expiration.tsx
+++ b/website/src/shared/Expiration.tsx
@@ -48,6 +48,12 @@ export const Expiration = (props: { control: Control<any> }) => {
               control={<Radio color="primary" />}
               label={t('expiration.optionOneWeekLabel') as string}
             />
+            <FormControlLabel
+              labelPlacement="end"
+              value="2592000"
+              control={<Radio color="primary" />}
+              label={t('expiration.optionOneMonthLabel') as string}
+            />
           </RadioGroup>
         )}
       />


### PR DESCRIPTION
Hey,

Thanks for your great work!

I like using YoPass to securely exchange access data with my customers.

Unfortunately, after 1.5 weeks, I often get asked, ‘Can you send me the password again? I've only just had a chance to look at it.’ 

A new monthly option would be perfect for this.

Thanks.