### PR TITLE
fix/docker build action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN yarn install --network-timeout 600000 && yarn build
 
 FROM gcr.io/distroless/base
 COPY --from=app /yopass/yopass /yopass/yopass-server /
-COPY --from=website /website/build /public
+COPY --from=website /website/dist /public
 ENTRYPOINT ["/yopass-server"]


### PR DESCRIPTION
"Publish Docker image" job does not work anymore.
Artifacts generated by `vite build` are located in the dist folder