### PR TITLE
fix(LanguageSwitcher): store language only when selected.

### DIFF
--- a/website/src/shared/components/LanguageSwitcher.tsx
+++ b/website/src/shared/components/LanguageSwitcher.tsx
@@ -10,6 +10,8 @@ export default function LanguageSwitcher() {
 
   const handleLanguageChange = (languageCode: string) => {
     i18n.changeLanguage(languageCode);
+    // Only store language preference when user explicitly selects it
+    localStorage.setItem('i18nextLng', languageCode);
   };
 
   return (

--- a/website/src/shared/lib/i18n.ts
+++ b/website/src/shared/lib/i18n.ts
@@ -26,7 +26,7 @@ i18n
 
     detection: {
       order: ['localStorage', 'navigator', 'htmlTag'],
-      caches: ['localStorage'],
+      caches: [], // Don't cache auto-detected language
     },
   });
 


### PR DESCRIPTION
- Updated LanguageSwitcher component to save the user's language choice in localStorage when explicitly selected.
- Modified i18n configuration to prevent caching of auto-detected languages.