### PR TITLE
Refactor button styles and update localization strings

### DIFF
--- a/website/src/features/CreateSecret.tsx
+++ b/website/src/features/CreateSecret.tsx
@@ -168,7 +168,7 @@ export default function CreateSecret() {
         </div>
 
         <div className="form-control mt-6">
-          <button className="btn btn-primary w-full max-w-xs" type="submit">
+          <button className="btn btn-primary w-full" type="submit">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               className="h-6 w-6 mr-2"

--- a/website/src/features/Upload.tsx
+++ b/website/src/features/Upload.tsx
@@ -245,7 +245,7 @@ export default function Upload() {
 
         <div className="form-control mt-6">
           <button
-            className="btn btn-primary w-full max-w-xs"
+            className="btn btn-primary w-full"
             type="submit"
             disabled={!file}
           >

--- a/website/src/shared/locales/en.json
+++ b/website/src/shared/locales/en.json
@@ -85,7 +85,7 @@
     "dialogCancel": "Cancel"
   },
   "expiration": {
-    "legend": "The encrypted message will be deleted automatically after",
+    "legend": "Deleted automatically after",
     "optionOneHourLabel": "One Hour",
     "optionOneDayLabel": "One Day",
     "optionOneWeekLabel": "One Week"

--- a/website/src/shared/locales/sv.json
+++ b/website/src/shared/locales/sv.json
@@ -85,7 +85,7 @@
     "dialogCancel": "Avbryt"
   },
   "expiration": {
-    "legend": "Det krypterade meddelandet kommer att tas bort automatiskt efter",
+    "legend": "Radera automatiskt efter",
     "optionOneHourLabel": "En timme",
     "optionOneDayLabel": "En dag",
     "optionOneWeekLabel": "En vecka"


### PR DESCRIPTION
- Removed 'max-w-xs' class from buttons in CreateSecret and Upload components for consistent styling.
- Simplified localization strings in English and Swedish for expiration legend.