### PR TITLE
Add trusted proxy support for accurate client IP logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,24 +87,57 @@ Command line flags:
 
 ```console
 $ yopass-server -h
-      --address string          listen address (default 0.0.0.0)
-      --database string         database backend ('memcached' or 'redis') (default "memcached")
-      --max-length int          max length of encrypted secret (default 10000)
-      --memcached string        Memcached address (default "localhost:11211")
-      --metrics-port int        metrics server listen port (default -1)
-      --port int                listen port (default 1337)
-      --redis string            Redis URL (default "redis://localhost:6379/0")
-      --tls-cert string         path to TLS certificate
-      --tls-key string          path to TLS key
-      --cors-allow-origin       Access-Control-Allow-Origin CORS setting (default *)
-      --force-onetime-secrets   reject non onetime secrets from being created
-      --disable-upload          disable the /file upload endpoints
-      --prefetch-secret         display information that the secret might be one time use (default true)
-      --disable-features        disable features section on frontend
-      --no-language-switcher    disable the language switcher in the UI
+      --address string             listen address (default 0.0.0.0)
+      --database string            database backend ('memcached' or 'redis') (default "memcached")
+      --max-length int             max length of encrypted secret (default 10000)
+      --memcached string           Memcached address (default "localhost:11211")
+      --metrics-port int           metrics server listen port (default -1)
+      --port int                   listen port (default 1337)
+      --redis string               Redis URL (default "redis://localhost:6379/0")
+      --tls-cert string            path to TLS certificate
+      --tls-key string             path to TLS key
+      --cors-allow-origin          Access-Control-Allow-Origin CORS setting (default *)
+      --force-onetime-secrets      reject non onetime secrets from being created
+      --disable-upload             disable the /file upload endpoints
+      --prefetch-secret            display information that the secret might be one time use (default true)
+      --disable-features           disable features section on frontend
+      --no-language-switcher       disable the language switcher in the UI
+      --trusted-proxies strings    trusted proxy IP addresses or CIDR blocks for X-Forwarded-For header validation
 ```
 
 Encrypted secrets can be stored either in Memcached or Redis by changing the `--database` flag.
+
+### Proxy Configuration
+
+When Yopass is deployed behind a reverse proxy or load balancer (such as Nginx, Caddy, Cloudflare, or AWS ALB), you may want to log the real client IP addresses instead of the proxy's IP. Yopass supports trusted proxy configuration for secure handling of `X-Forwarded-For` headers.
+
+**Security Note**: X-Forwarded-For headers are only trusted when requests come from explicitly configured trusted proxies. This prevents IP spoofing from untrusted sources.
+
+#### Examples:
+
+```bash
+# Trust a single proxy IP
+yopass-server --trusted-proxies 192.168.1.100
+
+# Trust multiple proxy IPs
+yopass-server --trusted-proxies 192.168.1.100,10.0.0.50
+
+# Trust proxy subnets (CIDR notation)
+yopass-server --trusted-proxies 192.168.1.0/24,10.0.0.0/8
+
+# Environment variable (useful for Docker)
+export TRUSTED_PROXIES="192.168.1.0/24,10.0.0.0/8"
+yopass-server
+```
+
+#### Common Proxy Scenarios:
+
+- **Nginx/Apache**: Use the IP address of your reverse proxy server
+- **Cloudflare**: Use Cloudflare's IP ranges (available from their documentation)
+- **AWS ALB/ELB**: Use your VPC's CIDR block or the load balancer's subnet
+- **Docker networks**: Use the Docker network's gateway IP or subnet
+
+Without trusted proxies configured, Yopass will always use the direct connection IP for security, which is the recommended default behavior.
 
 ### Docker Compose
 

--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -43,6 +43,7 @@ func init() {
 	pflag.Bool("prefetch-secret", true, "Display information that the secret might be one time use")
 	pflag.Bool("disable-features", false, "disable features")
 	pflag.Bool("no-language-switcher", false, "disable the language switcher in the UI")
+	pflag.StringSlice("trusted-proxies", []string{}, "trusted proxy IP addresses or CIDR blocks for X-Forwarded-For header validation")
 	pflag.CommandLine.AddGoFlag(&flag.Flag{Name: "log-level", Usage: "Log level", Value: &logLevel})
 
 	viper.AutomaticEnv()
@@ -71,6 +72,7 @@ func main() {
 		ForceOneTimeSecrets: viper.GetBool("force-onetime-secrets"),
 		AssetPath:           viper.GetString("asset-path"),
 		Logger:              logger,
+		TrustedProxies:      viper.GetStringSlice("trusted-proxies"),
 	}
 	yopassSrv := &http.Server{
 		Addr:      fmt.Sprintf("%s:%d", viper.GetString("address"), viper.GetInt("port")),

--- a/pkg/server/logging_test.go
+++ b/pkg/server/logging_test.go
@@ -12,16 +12,99 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
+func TestGetRealClientIP(t *testing.T) {
+	tests := []struct {
+		name              string
+		trustedProxies    []string
+		remoteAddr        string
+		xForwardedFor     string
+		expectedIP        string
+	}{
+		{
+			name:           "No trusted proxies - should use RemoteAddr",
+			trustedProxies: []string{},
+			remoteAddr:     "192.168.1.100:12345",
+			xForwardedFor:  "203.0.113.10",
+			expectedIP:     "192.168.1.100",
+		},
+		{
+			name:           "Trusted proxy with single IP - should use X-Forwarded-For",
+			trustedProxies: []string{"192.168.1.100"},
+			remoteAddr:     "192.168.1.100:12345",
+			xForwardedFor:  "203.0.113.10",
+			expectedIP:     "203.0.113.10",
+		},
+		{
+			name:           "Untrusted proxy - should use RemoteAddr",
+			trustedProxies: []string{"192.168.1.200"},
+			remoteAddr:     "192.168.1.100:12345",
+			xForwardedFor:  "203.0.113.10",
+			expectedIP:     "192.168.1.100",
+		},
+		{
+			name:           "Trusted proxy with CIDR - should use X-Forwarded-For",
+			trustedProxies: []string{"192.168.1.0/24"},
+			remoteAddr:     "192.168.1.100:12345",
+			xForwardedFor:  "203.0.113.10",
+			expectedIP:     "203.0.113.10",
+		},
+		{
+			name:           "Multiple IPs in X-Forwarded-For - should use first",
+			trustedProxies: []string{"192.168.1.100"},
+			remoteAddr:     "192.168.1.100:12345",
+			xForwardedFor:  "203.0.113.10, 10.0.0.1, 172.16.0.1",
+			expectedIP:     "203.0.113.10",
+		},
+		{
+			name:           "Invalid IP in X-Forwarded-For - should fallback to RemoteAddr",
+			trustedProxies: []string{"192.168.1.100"},
+			remoteAddr:     "192.168.1.100:12345",
+			xForwardedFor:  "invalid-ip",
+			expectedIP:     "192.168.1.100",
+		},
+		{
+			name:           "Empty X-Forwarded-For - should fallback to RemoteAddr",
+			trustedProxies: []string{"192.168.1.100"},
+			remoteAddr:     "192.168.1.100:12345",
+			xForwardedFor:  "",
+			expectedIP:     "192.168.1.100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &Server{
+				TrustedProxies: tt.trustedProxies,
+			}
+
+			req := httptest.NewRequest("GET", "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.xForwardedFor != "" {
+				req.Header.Set("X-Forwarded-For", tt.xForwardedFor)
+			}
+
+			actualIP := server.getRealClientIP(req)
+			assert.Equal(t, tt.expectedIP, actualIP)
+		})
+	}
+}
+
 func TestHTTPLogFormatter(t *testing.T) {
-	t.Run("Log request", func(t *testing.T) {
+	t.Run("Log request with no trusted proxies", func(t *testing.T) {
 		ts := time.Now()
 		request := httptest.NewRequest("GET", "https://yopass.se/", nil)
+		request.Header.Set("X-Forwarded-For", "203.0.113.10")
 		host, _, _ := net.SplitHostPort(request.RemoteAddr)
 
 		loggerCore, logs := observer.New(zap.DebugLevel)
 		logger := zap.New(loggerCore)
 
-		formatter := httpLogFormatter(logger)
+		server := &Server{
+			Logger:         logger,
+			TrustedProxies: []string{}, // No trusted proxies
+		}
+
+		formatter := server.httpLogFormatter()
 		formatter(nil, handlers.LogFormatterParams{
 			Request:    request,
 			TimeStamp:  ts,
@@ -41,7 +124,67 @@ func TestHTTPLogFormatter(t *testing.T) {
 		for _, f := range fields {
 			switch f.Key {
 			case "host":
+				// Should use RemoteAddr, not X-Forwarded-For
 				assert.Equal(t, host, f.String)
+				assert.NotEqual(t, "203.0.113.10", f.String)
+			case "timestamp":
+				assert.Equal(t, ts.UnixNano(), f.Integer)
+			case "method":
+				assert.Equal(t, "GET", f.String)
+			case "uri":
+				assert.Equal(t, "https://yopass.se/", f.String)
+			case "protocol":
+				assert.Equal(t, "HTTP/1.1", f.String)
+			case "responseStatus":
+				assert.Equal(t, int64(200), f.Integer)
+			case "responseSize":
+				assert.Equal(t, int64(50), f.Integer)
+			default:
+				t.Fatalf("Unexpected fields %s", f.Key)
+			}
+		}
+
+		if len(fields) != 7 {
+			t.Fatalf("Expected 7 fields but got %d", len(fields))
+		}
+	})
+
+	t.Run("Log request with trusted proxy", func(t *testing.T) {
+		ts := time.Now()
+		request := httptest.NewRequest("GET", "https://yopass.se/", nil)
+		request.RemoteAddr = "192.168.1.100:12345"
+		request.Header.Set("X-Forwarded-For", "203.0.113.10")
+
+		loggerCore, logs := observer.New(zap.DebugLevel)
+		logger := zap.New(loggerCore)
+
+		server := &Server{
+			Logger:         logger,
+			TrustedProxies: []string{"192.168.1.100"}, // Trust this proxy
+		}
+
+		formatter := server.httpLogFormatter()
+		formatter(nil, handlers.LogFormatterParams{
+			Request:    request,
+			TimeStamp:  ts,
+			StatusCode: 200,
+			Size:       50,
+		})
+
+		if logs.Len() != 1 {
+			t.Fatalf("Expected 1 log entry got %d", logs.Len())
+		}
+		infoLogs := logs.FilterLevelExact(zap.InfoLevel).All()
+		if len(infoLogs) != 1 {
+			t.Fatalf("Expected 1 info level log but got %d", len(infoLogs))
+		}
+
+		fields := infoLogs[0].Context
+		for _, f := range fields {
+			switch f.Key {
+			case "host":
+				// Should use X-Forwarded-For since request comes from trusted proxy
+				assert.Equal(t, "203.0.113.10", f.String)
 			case "timestamp":
 				assert.Equal(t, ts.UnixNano(), f.Integer)
 			case "method":
@@ -68,7 +211,11 @@ func TestHTTPLogFormatter(t *testing.T) {
 		loggerCore, logs := observer.New(zap.DebugLevel)
 		logger := zap.New(loggerCore)
 
-		formatter := httpLogFormatter(logger)
+		server := &Server{
+			Logger: logger,
+		}
+
+		formatter := server.httpLogFormatter()
 		formatter(nil, handlers.LogFormatterParams{})
 
 		if err := logger.Sync(); err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,6 +25,7 @@ type Server struct {
 	ForceOneTimeSecrets bool
 	AssetPath           string
 	Logger              *zap.Logger
+	TrustedProxies      []string
 }
 
 // createSecret creates secret
@@ -193,7 +194,7 @@ func (y *Server) HTTPHandler() http.Handler {
 	}
 
 	mx.PathPrefix("/").Handler(http.FileServer(http.Dir(y.AssetPath)))
-	return handlers.CustomLoggingHandler(nil, SecurityHeadersHandler(mx), httpLogFormatter(y.Logger))
+	return handlers.CustomLoggingHandler(nil, SecurityHeadersHandler(mx), y.httpLogFormatter())
 }
 
 const keyParameter = "{key:(?:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})}"

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -835,10 +835,12 @@ func TestGetSecretStatusWriteError(t *testing.T) {
 
 func TestHTTPLogFormatterEdgeCases(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	formatter := httpLogFormatter(logger)
+	server := &Server{Logger: logger}
+	formatter := server.httpLogFormatter()
 	
 	// Test with nil logger
-	nilFormatter := httpLogFormatter(nil)
+	nilServer := &Server{Logger: nil}
+	nilFormatter := nilServer.httpLogFormatter()
 	if nilFormatter == nil {
 		t.Error("Formatter should not be nil even with nil logger")
 	}


### PR DESCRIPTION
- Introduced the `--trusted-proxies` flag to configure trusted proxy IPs or CIDR blocks for validating `X-Forwarded-For` headers.
- Updated the `getRealClientIP` function to return the correct client IP based on trusted proxies.
- Enhanced logging functionality to utilize the real client IP when requests come from trusted proxies.
- Added comprehensive tests to ensure correct behavior in various proxy scenarios.

This change improves security by preventing IP spoofing while allowing accurate logging of client IPs behind proxies.

fixes #2312