### PR TITLE
Switch navbar button between Upload and Text based on current route

### DIFF
--- a/website/src/app/App.tsx
+++ b/website/src/app/App.tsx
@@ -10,10 +10,10 @@ export default function App() {
   const { DISABLE_UPLOAD } = useConfig();
   return (
     <div className="min-h-screen bg-base-200">
-      <Navbar />
-
-      {/* Main Content */}
       <HashRouter>
+        <Navbar />
+
+        {/* Main Content */}
         <div className="container mx-auto px-4 py-8">
           <div className="card bg-base-100 shadow-xl">
             <div className="card-body">

--- a/website/src/shared/components/Navbar.tsx
+++ b/website/src/shared/components/Navbar.tsx
@@ -8,11 +8,13 @@ import {
 import { useConfig } from '../hooks/useConfig';
 import LanguageSwitcher from './LanguageSwitcher';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 
 export default function Navbar() {
   const [mode, setMode] = useState<LogicalTheme>(getInitialLogicalTheme);
   const { DISABLE_UPLOAD, NO_LANGUAGE_SWITCHER } = useConfig();
   const { t } = useTranslation();
+  const location = useLocation();
   useEffect(() => {
     const daisy = logicalToDaisyTheme(mode);
     document.documentElement.setAttribute('data-theme', daisy);
@@ -36,11 +38,11 @@ export default function Navbar() {
         </a>
       </div>
       <div className="flex-none flex items-center gap-4">
-        {!DISABLE_UPLOAD && (
+        {!DISABLE_UPLOAD && location.pathname === '/upload' ? (
           <a
             className="btn btn-ghost gap-2"
-            href="#/upload"
-            title={t('header.buttonUpload')}
+            href="#/"
+            title={t('header.buttonText')}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -53,11 +55,35 @@ export default function Navbar() {
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
+                d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75"
               />
             </svg>
-            {t('header.buttonUpload')}
+            {t('header.buttonText')}
           </a>
+        ) : (
+          !DISABLE_UPLOAD && (
+            <a
+              className="btn btn-ghost gap-2"
+              href="#/upload"
+              title={t('header.buttonUpload')}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="w-6 h-6"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
+                />
+              </svg>
+              {t('header.buttonUpload')}
+            </a>
+          )
         )}
 
         {!NO_LANGUAGE_SWITCHER && <LanguageSwitcher />}

--- a/website/src/shared/locales/de.json
+++ b/website/src/shared/locales/de.json
@@ -109,6 +109,7 @@
   "header": {
     "buttonHome": "Startseite",
     "buttonUpload": "Hochladen",
+    "buttonText": "Text",
     "appName": "Yopass"
   },
   "common": {

--- a/website/src/shared/locales/en.json
+++ b/website/src/shared/locales/en.json
@@ -109,6 +109,7 @@
   "header": {
     "buttonHome": "Home",
     "buttonUpload": "Upload",
+    "buttonText": "Text",
     "appName": "Yopass"
   },
   "common": {

--- a/website/src/shared/locales/sv.json
+++ b/website/src/shared/locales/sv.json
@@ -109,6 +109,7 @@
   "header": {
     "buttonHome": "Hem",
     "buttonUpload": "Ladda upp",
+    "buttonText": "Text",
     "appName": "Yopass"
   },
   "common": {

--- a/website/tests/navbar-button-switching.spec.ts
+++ b/website/tests/navbar-button-switching.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from '@playwright/test';
+import { MockAPI } from './helpers/mock-api';
+
+test.describe('Navbar Button Switching', () => {
+  let mockAPI: MockAPI;
+
+  test.beforeEach(async ({ page }) => {
+    mockAPI = new MockAPI(page);
+    await mockAPI.mockConfigEndpoint();
+  });
+
+  test.afterEach(async () => {
+    await mockAPI.clearAllMocks();
+  });
+
+  test('should show Upload button on home page', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Check that Upload button is visible
+    const uploadButton = page.locator('a[href="#/upload"]');
+    await expect(uploadButton).toBeVisible();
+    await expect(uploadButton).toHaveText('Upload');
+
+    // Check that Text button is not visible
+    const textButton = page.locator('a[href="#/"]').filter({ hasText: 'Text' });
+    await expect(textButton).not.toBeVisible();
+  });
+
+  test('should show Text button on upload page', async ({ page }) => {
+    await page.goto('/#/upload');
+    await page.waitForLoadState('networkidle');
+
+    // Check that Text button is visible
+    const textButton = page.locator('a[href="#/"]').filter({ hasText: 'Text' });
+    await expect(textButton).toBeVisible();
+    await expect(textButton).toHaveText('Text');
+
+    // Check that Upload button is not visible
+    const uploadButton = page.locator('a[href="#/upload"]');
+    await expect(uploadButton).not.toBeVisible();
+  });
+
+  test('should switch from Upload button to Text button when navigating to upload page', async ({
+    page,
+  }) => {
+    // Start on home page
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Verify Upload button is visible
+    const uploadButton = page.locator('a[href="#/upload"]');
+    await expect(uploadButton).toBeVisible();
+
+    // Click Upload button to navigate to upload page
+    await uploadButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // Verify we're on upload page and Text button is now visible
+    await expect(page.locator('h2:has-text("Upload file")')).toBeVisible();
+    const textButton = page.locator('a[href="#/"]').filter({ hasText: 'Text' });
+    await expect(textButton).toBeVisible();
+    await expect(uploadButton).not.toBeVisible();
+  });
+
+  test('should switch from Text button to Upload button when navigating to home page', async ({
+    page,
+  }) => {
+    // Start on upload page
+    await page.goto('/#/upload');
+    await page.waitForLoadState('networkidle');
+
+    // Verify Text button is visible
+    const textButton = page.locator('a[href="#/"]').filter({ hasText: 'Text' });
+    await expect(textButton).toBeVisible();
+
+    // Click Text button to navigate to home page
+    await textButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // Verify we're on home page and Upload button is now visible
+    await expect(page.locator('h2:has-text("Encrypt message")')).toBeVisible();
+    const uploadButton = page.locator('a[href="#/upload"]');
+    await expect(uploadButton).toBeVisible();
+    await expect(textButton).not.toBeVisible();
+  });
+
+  test('should use correct icons for each button', async ({ page }) => {
+    // Test Upload button icon on home page
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const uploadButton = page.locator('a[href="#/upload"]');
+    await expect(uploadButton).toBeVisible();
+
+    // Check for upload icon (SVG with upload path)
+    const uploadIcon = uploadButton.locator('svg path[d*="M3 16.5v2.25"]');
+    await expect(uploadIcon).toBeVisible();
+
+    // Navigate to upload page
+    await page.goto('/#/upload');
+    await page.waitForLoadState('networkidle');
+
+    const textButton = page.locator('a[href="#/"]').filter({ hasText: 'Text' });
+    await expect(textButton).toBeVisible();
+
+    // Check for envelope/mail icon (SVG with mail path)
+    const textIcon = textButton.locator('svg path[d*="M21.75 6.75v10.5"]');
+    await expect(textIcon).toBeVisible();
+  });
+
+  test('should maintain button switching behavior with browser navigation', async ({
+    page,
+  }) => {
+    // Start on home page
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('a[href="#/upload"]')).toBeVisible();
+
+    // Navigate to upload page via URL
+    await page.goto('/#/upload');
+    await page.waitForLoadState('networkidle');
+    await expect(
+      page.locator('a[href="#/"]').filter({ hasText: 'Text' }),
+    ).toBeVisible();
+
+    // Go back using browser back button
+    await page.goBack();
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('a[href="#/upload"]')).toBeVisible();
+
+    // Go forward using browser forward button
+    await page.goForward();
+    await page.waitForLoadState('networkidle');
+    await expect(
+      page.locator('a[href="#/"]').filter({ hasText: 'Text' }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
- Add conditional button switching in navbar based on current page
- When on /upload page: show "Text" button with mail icon linking to home
- When on other pages: show "Upload" button with upload icon
- Move Navbar inside HashRouter to enable useLocation hook
- Add mail icon for text encryption button
- Add translations for "Text" button in EN/SV/DE
- Add comprehensive test suite for button switching behavior