### PR TITLE
Fix expiration label overflow in small screens

### DIFF
--- a/website/src/features/CreateSecret.tsx
+++ b/website/src/features/CreateSecret.tsx
@@ -94,7 +94,7 @@ export default function CreateSecret() {
 
         <div className="form-control mt-6">
           <label className="label">
-            <span className="label-text font-semibold text-base">
+            <span className="label-text font-semibold text-base text-balance">
               {t('expiration.legend')}
             </span>
           </label>

--- a/website/src/features/Upload.tsx
+++ b/website/src/features/Upload.tsx
@@ -167,7 +167,7 @@ export default function Upload() {
 
         <div className="form-control mt-6">
           <label className="label">
-            <span className="label-text font-semibold text-base">
+            <span className="label-text font-semibold text-base text-balance">
               {t('upload.expirationLegendFile')}
             </span>
           </label>


### PR DESCRIPTION
Fixes expiration label overflow in smaller screens:

File upload:
<img width="1253" height="860" alt="image" src="https://github.com/user-attachments/assets/645bdbd6-bd50-4101-8eca-9db4dd573b80" />

Text:
<img width="1253" height="860" alt="image" src="https://github.com/user-attachments/assets/f4c746d6-f801-4914-b7f5-883cb6cab25c" />
