### PR TITLE
Improve french translation

### DIFF
--- a/website/src/shared/locales/fr.json
+++ b/website/src/shared/locales/fr.json
@@ -22,7 +22,7 @@
   "display": {
     "titleFetching": "Déchiffrement...",
     "titleDecryptionKey": "Entrez la clé de déchiffrement",
-    "captionDecryptionKey": "Ne rafaichissez pas la page, le secret peut être limité à une seule consultation.",
+    "captionDecryptionKey": "Ne rafraîchissez pas la page, le secret peut être limité à une seule consultation.",
     "inputDecryptionKeyPlaceholder": "Clé de déchiffrement",
     "inputDecryptionKeyLabel": "Une clé de déchiffrement est nécessaire",
     "errorInvalidPassword": "Mot de passe invalide, veuillez réessayer",
@@ -32,11 +32,11 @@
     "buttonDecryptSecret": "Déchiffrer le secret",
     "loading": "Chargement...",
     "secureMessageTitle": "Message sécurisé",
-    "secureMessageSubtitle": "Vous avez reçu un message sécurisé qui ne peut être consulté qu'un fois",
+    "secureMessageSubtitle": "Vous avez reçu un message sécurisé qui ne peut être consulté qu'une fois",
     "importantTitle": "Important",
     "oneTimeWarning": "Ce message s'auto-détruira après consultation. Une fois révélé, il ne pourra plus être consulté",
     "oneTimeWarningReady": "Assurez-vous d'être prêt à consulter le message",
-    "buttonRevealMessage": "Reveler le message sécurisé"
+    "buttonRevealMessage": "Révéler le message sécurisé"
   },
   "error": {
     "title": "Le secret n'existe pas !",
@@ -47,17 +47,17 @@
     "titleBrokenLink": "Lien incomplet",
     "subtitleBrokenLink": "Le lien doit être complet pour que le déchiffrement fonctionne, il doit lui manquer des caractères.",
     "titleExpired": "Expiré",
-    "subtitleExpired": "Pas de secret éternel. Tout les secrets expirent et s'auto-détruise automatiquement. La durée de vie va d'une heure à une semaine."
+    "subtitleExpired": "Pas de secret éternel. Tous les secrets expirent et s'auto-détruise automatiquement. La durée de vie va d'une heure à une semaine."
   },
   "result": {
-    "title": "Secret stocké en base de donnée",
-    "subtitle": "Votre secret à été chiffré et stocké. Partagez le grace à ces liens",
+    "title": "Secret stocké en base de données",
+    "subtitle": "Votre secret à été chiffré et stocké. Partagez le grâce à ces liens",
     "subtitleDownloadOnce": "Ce secret n'est consultable qu'une seule fois. Ne l'ouvrez donc pas vous-mêmes. Il est conseillé d'envoyer le lien et la clé par des canaux de communications séparés.",
     "reminderTitle": "Rappel",
     "rowLabelOneClick": "Lien 1-click",
     "rowOneClickDescription": "Partagez ce lien pour un accès direct au secret",
     "rowLabelShortLink": "Lien",
-    "rowShortLinkDescription": "La clé de chiffrement doit être envoyée séparement",
+    "rowShortLinkDescription": "La clé de chiffrement doit être envoyée séparément",
     "rowLabelDecryptionKey": "Clé de déchiffrement",
     "rowDecryptionKeyDescription": "Nécessaire pour déchiffrer le secret"
   },
@@ -76,9 +76,9 @@
   },
   "delete": {
     "buttonDelete": "Supprimer",
-    "messageDeleted": "Le secret a été supprimer du serveur !",
+    "messageDeleted": "Le secret a été supprimé du serveur !",
     "dialogTitle": "Supprimer le secret ?",
-    "dialogMessage": "Êtes vous sûr de vouloir supprimer ce secret ?",
+    "dialogMessage": "Êtes-vous sûr de vouloir supprimer ce secret ?",
     "dialogProgress": "Suppression...",
     "dialogConfirm": "Supprimer",
     "dialogCancel": "Annuler"
@@ -93,21 +93,21 @@
     "title": "Partagez facilement vos secrets de manière sécurisée",
     "subtitle": "Yopass a été créé pour réduire le nombre de mot de passe en clair dans les emails et les chats, en chiffrant votre secret et en générant un lien visible une seule fois.",
     "featureEndToEndTitle": "Chiffrement de bout-en-bout",
-    "featureEndToEndText": "Les chiffrements et déchiffrements sont fait localement dans le navigateur. La clé n'est jamais stockée sur le serveur.",
+    "featureEndToEndText": "Les chiffrements et déchiffrements sont faits localement dans le navigateur. La clé n'est jamais stockée sur le serveur.",
     "featureSelfDestructionTitle": "Auto-destruction",
     "featureSelfDestructionText": "Les messages chiffrés ont une durée de vie définie, et seront supprimés après expiration.",
     "featureOneTimeTitle": "Téléchargement unique",
-    "featureOneTimeText": "Les messages chiffrés ne sont consultables qu'une seule fois, réduisant le risque de consultation par un tiers.",
+    "featureOneTimeText": "Les messages chiffrés sont consultables qu'une seule fois, réduisant le risque de consultation par un tiers.",
     "featureSimpleSharingTitle": "Partage rapide",
-    "featureSimpleSharingText": "Yopass génère un lien unique pour le message ou le fichier chiffré. La clé de déchiffrement peut aussi être envoyée séparement.",
+    "featureSimpleSharingText": "Yopass génère un lien unique pour le message ou le fichier chiffré. La clé de déchiffrement peut aussi être envoyée séparément.",
     "featureNoAccountsTitle": "Pas besoin de compte",
-    "featureNoAccountsText": "Partager des secrets doit être simple et rapide. Aucune information additionnelle n'est stockée en base de donnée.",
+    "featureNoAccountsText": "Partager des secrets doit être simple et rapide. Aucune information additionnelle n'est stockée en base de données.",
     "featureOpenSourceTitle": "Logiciel Open Source",
     "featureOpenSourceText": "Yopass utilise un protocole de chiffrement basé sur un logiciel Open Source afin de rendre possible les audits et la soumission de fonctionnalités."
   },
   "header": {
-    "buttonHome": "Home",
-    "buttonUpload": "Upload",
+    "buttonHome": "Accueil",
+    "buttonUpload": "Télécharger",
     "buttonText": "Texte",
     "appName": "Yopass"
   },
@@ -116,8 +116,8 @@
     "copied": "Copié !"
   },
   "footer": {
-    "privacyNotice": "Privacy Notice",
-    "imprint": "Imprint",
+    "privacyNotice": "Politique de confidentialité",
+    "imprint": "Mentions légales",
     "createdBy": "Créé par"
   }
 }


### PR DESCRIPTION
Hello
While using Yopass, I noticed a few minor translation errors in French, so here is a PR to correct them.

To be sure, can you confirm that the `footer.imprint` variable refers to the legal notice page?