### PR TITLE
FEATURE: Add additional expiration options

### DIFF
--- a/cmd/yopass/main.go
+++ b/cmd/yopass/main.go
@@ -69,7 +69,7 @@ func init() {
 	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
 	pflag.String("api", viper.GetString("api"), "Yopass API server location")
 	pflag.String("decrypt", viper.GetString("decrypt"), "Decrypt secret URL")
-	pflag.String("expiration", viper.GetString("expiration"), "Duration after which secret will be deleted [1h, 1d, 1w]")
+	pflag.String("expiration", viper.GetString("expiration"), "Duration after which secret will be deleted [1h, 1d, 1w, 2w, 1m]")
 	pflag.String("file", viper.GetString("file"), "Read secret from file instead of stdin")
 	pflag.String("key", viper.GetString("key"), "Manual encryption/decryption key")
 	pflag.Bool("one-time", viper.GetBool("one-time"), "One-time download")
@@ -204,6 +204,10 @@ func expiration(s string) int32 {
 		return 3600 * 24
 	case "1w":
 		return 3600 * 24 * 7
+	case "2w":
+		return 3600 * 24 * 14
+	case "1m":
+		return 3600 * 24 * 30
 	default:
 		return 0
 	}


### PR DESCRIPTION
This pull request extends the supported expiration durations for secrets in the Yopass CLI. Users can now specify "2w" (2 weeks) and "1m" (1 month) as valid expiration options to align with the UI, in addition to the previously supported durations.

Expiration options update:

* Updated the help text for the `--expiration` flag in `main.go` to include "2w" (2 weeks) and "1m" (1 month) as valid choices.
* Added handling for "2w" and "1m" in the `expiration` function, mapping them to 14 and 30 days respectively.

Resolves https://github.com/jhaals/yopass/issues/3127