### PR TITLE
feat(server): add force-expiration parameter server side

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ $ yopass-server -h
       --tls-key string             path to TLS key
       --cors-allow-origin          Access-Control-Allow-Origin CORS setting (default *)
       --force-onetime-secrets      reject non onetime secrets from being created
+      --force-expiration int32     force a global expiration time in seconds (3600, 86400, or 604800). 0 means no forced expiration
       --disable-upload             disable the /file upload endpoints
       --prefetch-secret            display information that the secret might be one time use (default true)
       --disable-features           disable features section on frontend
@@ -180,6 +181,20 @@ docker run -p 127.0.0.1:80:1337 --link memcached_yopass:memcached -d jhaals/yopa
 ```
 
 Then point your reverse proxy that handles TLS connections to `127.0.0.1:80`.
+
+#### Forcing Expiration Time
+
+To enforce a maximum expiration time for all secrets server-side, use the `--force-expiration` flag or `FORCE_EXPIRATION` environment variable. Valid values are `3600` (1 hour), `86400` (1 day), or `604800` (1 week):
+
+```console
+# Enforce maximum 1 hour expiration using command flag
+docker run -p 127.0.0.1:80:1337 --link memcached_yopass:memcached -d jhaals/yopass --memcached=memcached:11211 --force-expiration=3600
+
+# Or using environment variable
+docker run -p 127.0.0.1:80:1337 --link memcached_yopass:memcached -e FORCE_EXPIRATION=3600 -d jhaals/yopass --memcached=memcached:11211
+```
+
+When force-expiration is set, the server enforces it as a **maximum limit**. Users can choose shorter expiration times but cannot exceed the configured maximum. The UI automatically hides options that exceed the server's limit and displays an informational message about the enforced maximum.
 
 ### Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ yopass-server -h
       --tls-key string             path to TLS key
       --cors-allow-origin          Access-Control-Allow-Origin CORS setting (default *)
       --force-onetime-secrets      reject non onetime secrets from being created
-      --force-expiration int32     force a global expiration time in seconds (3600, 86400, or 604800). 0 means no forced expiration
+      --force-expiration int32     enforce a maximum expiration time in seconds (3600, 86400, or 604800); shorter expirations are still allowed. 0 means no forced expiration
       --disable-upload             disable the /file upload endpoints
       --prefetch-secret            display information that the secret might be one time use (default true)
       --disable-features           disable features section on frontend

--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -69,9 +69,8 @@ func main() {
 	// Validate force-expiration if set
 	forceExpiration := viper.GetInt32("force-expiration")
 	if forceExpiration > 0 {
-		validValues := []int32{3600, 86400, 604800}
 		isValid := false
-		for _, v := range validValues {
+		for _, v := range server.ValidExpirations {
 			if forceExpiration == v {
 				isValid = true
 				break
@@ -81,7 +80,7 @@ func main() {
 			logger.Fatal(
 				"Invalid force-expiration value. Must be 0 (disabled), 3600 (1 hour), 86400 (1 day), or 604800 (1 week)",
 				zap.Int32("force-expiration", forceExpiration),
-				zap.Int32s("valid-values", validValues),
+				zap.Int32s("valid-values", server.ValidExpirations),
 			)
 		}
 		logger.Info("Force expiration enabled", zap.Int32("max-expiration-seconds", forceExpiration))

--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -38,7 +38,7 @@ func init() {
 	pflag.String("tls-cert", "", "path to TLS certificate")
 	pflag.String("tls-key", "", "path to TLS key")
 	pflag.Bool("force-onetime-secrets", false, "reject non onetime secrets from being created")
-	pflag.Int32("force-expiration", 0, "force a global expiration time in seconds (3600, 86400, or 604800). 0 means no forced expiration")
+	pflag.Int32("force-expiration", 0, "set a maximum expiration time in seconds (3600, 86400, or 604800). Clients may choose shorter expirations. 0 means no maximum expiration")
 	pflag.String("cors-allow-origin", "*", "Access-Control-Allow-Origin")
 	pflag.Bool("disable-upload", false, "disable the /file upload endpoints")
 	pflag.Bool("prefetch-secret", true, "Display information that the secret might be one time use")

--- a/deploy/docker-compose/insecure/docker-compose.yml
+++ b/deploy/docker-compose/insecure/docker-compose.yml
@@ -12,4 +12,9 @@ services:
     restart: always
     ports:
       - "127.0.0.1:80:80"
+    # Uncomment to force expiration time for all secrets:
+    # environment:
+    #   - FORCE_EXPIRATION=3600  # 1 hour (or 86400 for 1 day, 604800 for 1 week)
     command: "--memcached=memcached:11211 --port 80"
+    # Or use command line flag:
+    # command: "--memcached=memcached:11211 --port 80 --force-expiration=3600"

--- a/deploy/docker-compose/with-nginx-proxy-and-letsencrypt/docker-compose.yml
+++ b/deploy/docker-compose/with-nginx-proxy-and-letsencrypt/docker-compose.yml
@@ -38,7 +38,11 @@ services:
       - VIRTUAL_HOST=subdomain.yourdomain.tld
       - LETSENCRYPT_HOST=subdomain.yourdomain.tld
       - LETSENCRYPT_EMAIL=mail@yourdomain.tld
+      # Uncomment to force expiration time for all secrets:
+      # - FORCE_EXPIRATION=3600  # 1 hour (or 86400 for 1 day, 604800 for 1 week)
     command: "--memcached=memcached:11211 --port 80"
+    # Or use command line flag:
+    # command: "--memcached=memcached:11211 --port 80 --force-expiration=3600"
     expose:
       - "80"
 

--- a/deploy/yopass-k8.yaml
+++ b/deploy/yopass-k8.yaml
@@ -17,6 +17,13 @@ spec:
           image: jhaals/yopass
           args:
             - "--memcached=localhost:11211"
+            # Force all secrets to expire in 1 hour
+            # Valid values: 3600 (1 hour), 86400 (1 day), or 604800 (1 week)
+            - "--force-expiration=3600"
+          # Alternatively, use environment variables:
+          # env:
+          #   - name: FORCE_EXPIRATION
+          #     value: "3600"
           ports:
             - name: http
               containerPort: 1337

--- a/deploy/yopass-k8.yaml
+++ b/deploy/yopass-k8.yaml
@@ -17,9 +17,9 @@ spec:
           image: jhaals/yopass
           args:
             - "--memcached=localhost:11211"
-            # Force all secrets to expire in 1 hour
+            # Optional: force all secrets to expire in a fixed time
             # Valid values: 3600 (1 hour), 86400 (1 day), or 604800 (1 week)
-            - "--force-expiration=3600"
+            # - "--force-expiration=3600"
           # Alternatively, use environment variables:
           # env:
           #   - name: FORCE_EXPIRATION

--- a/pkg/server/force_expiration_test.go
+++ b/pkg/server/force_expiration_test.go
@@ -1,0 +1,222 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jhaals/yopass/pkg/yopass"
+)
+
+// mockDBWithCapture captures the secret that was stored
+type mockDBWithCapture struct {
+	capturedSecret yopass.Secret
+}
+
+func (db *mockDBWithCapture) Get(key string) (yopass.Secret, error) {
+	return db.capturedSecret, nil
+}
+
+func (db *mockDBWithCapture) Put(key string, secret yopass.Secret) error {
+	db.capturedSecret = secret
+	return nil
+}
+
+func (db *mockDBWithCapture) Delete(key string) (bool, error) {
+	return true, nil
+}
+
+func (db *mockDBWithCapture) Exists(key string) (bool, error) {
+	return true, nil
+}
+
+func (db *mockDBWithCapture) Status(key string) (bool, error) {
+	return db.capturedSecret.OneTime, nil
+}
+
+func TestForceExpiration(t *testing.T) {
+	validPGPMessage := `-----BEGIN PGP MESSAGE-----
+Version: OpenPGP.js v4.10.8
+Comment: https://openpgpjs.org
+
+wy4ECQMIRthQ3aO85NvgAfASIX3dTwsFVt0gshPu7n1tN05e8rpqxOk6PYNm
+xtt90k4BqHuTCLNlFRJjuiuE8zdIc+j5zTN5zihxUReVqokeqULLOx2FBMHZ
+sbfqaG/iDbp+qDOc98IagMyPrEqKDxnhVVOraXy5dD9RDsntLso=
+=0vwU
+-----END PGP MESSAGE-----`
+
+	tt := []struct {
+		name            string
+		statusCode      int
+		body            io.Reader
+		output          string
+		forceExpiration int32
+		requestedExp    int32
+		expectedExp     int32
+	}{
+		{
+			name:            "client requests 1 day but max is 1 hour - rejected",
+			statusCode:      400,
+			body:            strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 86400}`, strings.ReplaceAll(validPGPMessage, "\n", "\\n"))),
+			output:          "Expiration exceeds server maximum",
+			forceExpiration: 3600,
+			requestedExp:    86400,
+			expectedExp:     0,
+		},
+		{
+			name:            "client requests 1 hour with max 1 day - allowed",
+			statusCode:      200,
+			body:            strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 3600}`, strings.ReplaceAll(validPGPMessage, "\n", "\\n"))),
+			output:          "",
+			forceExpiration: 86400,
+			requestedExp:    3600,
+			expectedExp:     3600,
+		},
+		{
+			name:            "client requests 1 day with max 1 day - allowed",
+			statusCode:      200,
+			body:            strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 86400}`, strings.ReplaceAll(validPGPMessage, "\n", "\\n"))),
+			output:          "",
+			forceExpiration: 86400,
+			requestedExp:    86400,
+			expectedExp:     86400,
+		},
+		{
+			name:            "client requests 1 hour with max 1 week - allowed",
+			statusCode:      200,
+			body:            strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 3600}`, strings.ReplaceAll(validPGPMessage, "\n", "\\n"))),
+			output:          "",
+			forceExpiration: 604800,
+			requestedExp:    3600,
+			expectedExp:     3600,
+		},
+		{
+			name:            "no force expiration - client value 1 hour preserved",
+			statusCode:      200,
+			body:            strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 3600}`, strings.ReplaceAll(validPGPMessage, "\n", "\\n"))),
+			output:          "",
+			forceExpiration: 0,
+			requestedExp:    3600,
+			expectedExp:     3600,
+		},
+		{
+			name:            "no force expiration - client value 1 day preserved",
+			statusCode:      200,
+			body:            strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 86400}`, strings.ReplaceAll(validPGPMessage, "\n", "\\n"))),
+			output:          "",
+			forceExpiration: 0,
+			requestedExp:    86400,
+			expectedExp:     86400,
+		},
+		{
+			name:            "no force expiration - client value 1 week preserved",
+			statusCode:      200,
+			body:            strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 604800}`, strings.ReplaceAll(validPGPMessage, "\n", "\\n"))),
+			output:          "",
+			forceExpiration: 0,
+			requestedExp:    604800,
+			expectedExp:     604800,
+		},
+		{
+			name:            "invalid force expiration value",
+			statusCode:      500,
+			body:            strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 3600}`, strings.ReplaceAll(validPGPMessage, "\n", "\\n"))),
+			output:          "Server misconfiguration",
+			forceExpiration: 999,
+			requestedExp:    3600,
+			expectedExp:     0,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			db := &mockDBWithCapture{}
+
+			req, _ := http.NewRequest("POST", "/secret", tc.body)
+			rr := httptest.NewRecorder()
+			y := newTestServerWithExpiration(t, db, 10000, false, tc.forceExpiration)
+			y.createSecret(rr, req)
+
+			if rr.Code != tc.statusCode {
+				t.Fatalf(`Expected status code %d; got %d`, tc.statusCode, rr.Code)
+			}
+
+			if tc.output != "" {
+				var response struct {
+					Message string `json:"message"`
+				}
+				json.Unmarshal(rr.Body.Bytes(), &response)
+				if response.Message != tc.output {
+					t.Fatalf(`Expected error message "%s"; got "%s"`, tc.output, response.Message)
+				}
+			}
+
+			// Verify that the expiration is respected based on the maximum
+			if tc.statusCode == 200 {
+				if db.capturedSecret.Expiration != tc.expectedExp {
+					t.Fatalf(`Expected expiration to be %d; got %d`, tc.expectedExp, db.capturedSecret.Expiration)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigEndpointWithForceExpiration(t *testing.T) {
+	tt := []struct {
+		name            string
+		forceExpiration int32
+		expectInConfig  bool
+	}{
+		{
+			name:            "force expiration is set to 3600",
+			forceExpiration: 3600,
+			expectInConfig:  true,
+		},
+		{
+			name:            "force expiration is set to 86400",
+			forceExpiration: 86400,
+			expectInConfig:  true,
+		},
+		{
+			name:            "force expiration is not set",
+			forceExpiration: 0,
+			expectInConfig:  false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/config", nil)
+			rr := httptest.NewRecorder()
+			y := newTestServerWithExpiration(t, &mockDB{}, 10000, false, tc.forceExpiration)
+			y.configHandler(rr, req)
+
+			if rr.Code != 200 {
+				t.Fatalf(`Expected status code 200; got %d`, rr.Code)
+			}
+
+			var config map[string]interface{}
+			json.Unmarshal(rr.Body.Bytes(), &config)
+
+			if tc.expectInConfig {
+				val, exists := config["FORCE_EXPIRATION"]
+				if !exists {
+					t.Fatal("Expected FORCE_EXPIRATION to be in config, but it was not found")
+				}
+				// JSON unmarshaling converts int32 to float64
+				if int32(val.(float64)) != tc.forceExpiration {
+					t.Fatalf(`Expected FORCE_EXPIRATION to be %d; got %v`, tc.forceExpiration, val)
+				}
+			} else {
+				_, exists := config["FORCE_EXPIRATION"]
+				if exists {
+					t.Fatal("Expected FORCE_EXPIRATION to not be in config, but it was found")
+				}
+			}
+		})
+	}
+}

--- a/pkg/server/force_expiration_test.go
+++ b/pkg/server/force_expiration_test.go
@@ -149,7 +149,9 @@ sbfqaG/iDbp+qDOc98IagMyPrEqKDxnhVVOraXy5dD9RDsntLso=
 				var response struct {
 					Message string `json:"message"`
 				}
-				json.Unmarshal(rr.Body.Bytes(), &response)
+				if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+					t.Fatalf("Failed to unmarshal response body: %v", err)
+				}
 				if response.Message != tc.output {
 					t.Fatalf(`Expected error message "%s"; got "%s"`, tc.output, response.Message)
 				}
@@ -200,7 +202,9 @@ func TestConfigEndpointWithForceExpiration(t *testing.T) {
 			}
 
 			var config map[string]interface{}
-			json.Unmarshal(rr.Body.Bytes(), &config)
+			if err := json.Unmarshal(rr.Body.Bytes(), &config); err != nil {
+				t.Fatalf("Failed to unmarshal config response: %v", err)
+			}
 
 			if tc.expectInConfig {
 				val, exists := config["FORCE_EXPIRATION"]

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,11 +52,6 @@ func (y *Server) createSecret(w http.ResponseWriter, request *http.Request) {
 
 	// Enforce maximum expiration if force-expiration is set
 	if y.ForceExpiration > 0 {
-		if !validExpiration(y.ForceExpiration) {
-			y.Logger.Error("Invalid force-expiration configured", zap.Int32("expiration", y.ForceExpiration))
-			http.Error(w, `{"message": "Server misconfiguration"}`, http.StatusInternalServerError)
-			return
-		}
 		// Client can set a shorter expiration, but not longer than the forced maximum
 		if s.Expiration > y.ForceExpiration {
 			http.Error(w, `{"message": "Expiration exceeds server maximum"}`, http.StatusBadRequest)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,6 +52,11 @@ func (y *Server) createSecret(w http.ResponseWriter, request *http.Request) {
 
 	// Enforce maximum expiration if force-expiration is set
 	if y.ForceExpiration > 0 {
+		if !validExpiration(y.ForceExpiration) {
+			y.Logger.Error("Server misconfiguration: invalid force-expiration value", zap.Int32("value", y.ForceExpiration))
+			http.Error(w, `{"message": "Server misconfiguration"}`, http.StatusInternalServerError)
+			return
+		}
 		// Client can set a shorter expiration, but not longer than the forced maximum
 		if s.Expiration > y.ForceExpiration {
 			http.Error(w, `{"message": "Expiration exceeds server maximum"}`, http.StatusBadRequest)
@@ -224,10 +229,14 @@ func (y *Server) HTTPHandler() http.Handler {
 
 const keyParameter = "{key:(?:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})}"
 
+// ValidExpirations contains the allowed expiration values in seconds:
+// 3600 (1 hour), 86400 (1 day), 604800 (1 week)
+var ValidExpirations = []int32{3600, 86400, 604800}
+
 // validExpiration validates that expiration is either
 // 3600(1hour), 86400(1day) or 604800(1week)
 func validExpiration(expiration int32) bool {
-	for _, ttl := range []int32{3600, 86400, 604800} {
+	for _, ttl := range ValidExpirations {
 		if ttl == expiration {
 			return true
 		}

--- a/website/src/shared/components/SecretOptions.tsx
+++ b/website/src/shared/components/SecretOptions.tsx
@@ -66,7 +66,9 @@ export function SecretOptions({
               ></path>
             </svg>
             <span>
-              Server enforced maximum expiration: {getExpirationLabel(config.FORCE_EXPIRATION)}
+              {t('expiration.serverEnforcedMaximumExpiration', {
+                value: getExpirationLabel(config.FORCE_EXPIRATION),
+              })}
             </span>
           </div>
         )}

--- a/website/src/shared/components/SecretOptions.tsx
+++ b/website/src/shared/components/SecretOptions.tsx
@@ -28,6 +28,20 @@ export function SecretOptions({
   const { t } = useTranslation();
   const config = useConfig();
 
+  const maxExpiration = config?.FORCE_EXPIRATION || 604800;
+  const expirationOptions = [
+    { value: 3600, label: t('expiration.optionOneHourLabel') },
+    { value: 86400, label: t('expiration.optionOneDayLabel') },
+    { value: 604800, label: t('expiration.optionOneWeekLabel') },
+  ].filter((option) => option.value <= maxExpiration);
+
+  const getExpirationLabel = (seconds: number) => {
+    if (seconds === 3600) return '1 hour';
+    if (seconds === 86400) return '1 day';
+    if (seconds === 604800) return '1 week';
+    return `${seconds} seconds`;
+  };
+
   return (
     <>
       <div className="form-control mt-6">
@@ -36,41 +50,42 @@ export function SecretOptions({
             {expirationLabel || t('expiration.legend')}
           </span>
         </label>
+        {config?.FORCE_EXPIRATION && (
+          <div className="alert alert-info mb-2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              className="stroke-current shrink-0 w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              ></path>
+            </svg>
+            <span>
+              Server enforced maximum expiration: {getExpirationLabel(config.FORCE_EXPIRATION)}
+            </span>
+          </div>
+        )}
         <div className="flex flex-wrap gap-4 mt-2">
-          <label className="cursor-pointer flex items-center space-x-3 p-2 rounded-md hover:bg-base-200 transition-colors">
-            <input
-              type="radio"
-              {...register('expiration')}
-              className="radio radio-primary"
-              defaultChecked={true}
-              value="3600"
-            />
-            <span className="label-text font-medium">
-              {t('expiration.optionOneHourLabel')}
-            </span>
-          </label>
-          <label className="cursor-pointer flex items-center space-x-3 p-2 rounded-md hover:bg-base-200 transition-colors">
-            <input
-              type="radio"
-              {...register('expiration')}
-              className="radio radio-primary"
-              value="86400"
-            />
-            <span className="label-text font-medium">
-              {t('expiration.optionOneDayLabel')}
-            </span>
-          </label>
-          <label className="cursor-pointer flex items-center space-x-3 p-2 rounded-md hover:bg-base-200 transition-colors">
-            <input
-              type="radio"
-              {...register('expiration')}
-              className="radio radio-primary"
-              value="604800"
-            />
-            <span className="label-text font-medium">
-              {t('expiration.optionOneWeekLabel')}
-            </span>
-          </label>
+          {expirationOptions.map((option, index) => (
+            <label
+              key={option.value}
+              className="cursor-pointer flex items-center space-x-3 p-2 rounded-md hover:bg-base-200 transition-colors"
+            >
+              <input
+                type="radio"
+                {...register('expiration')}
+                className="radio radio-primary"
+                defaultChecked={index === 0}
+                value={option.value}
+              />
+              <span className="label-text font-medium">{option.label}</span>
+            </label>
+          ))}
         </div>
         <div className="mt-6 space-y-4">
           {!config?.FORCE_ONETIME_SECRETS && (

--- a/website/src/shared/components/SecretOptions.tsx
+++ b/website/src/shared/components/SecretOptions.tsx
@@ -28,19 +28,18 @@ export function SecretOptions({
   const { t } = useTranslation();
   const config = useConfig();
 
-  const maxExpiration = config?.FORCE_EXPIRATION || 604800;
-  const expirationOptions = [
+  const allExpirationOptions = [
     { value: 3600, label: t('expiration.optionOneHourLabel') },
     { value: 86400, label: t('expiration.optionOneDayLabel') },
     { value: 604800, label: t('expiration.optionOneWeekLabel') },
-  ].filter((option) => option.value <= maxExpiration);
+  ];
 
-  const getExpirationLabel = (seconds: number) => {
-    if (seconds === 3600) return '1 hour';
-    if (seconds === 86400) return '1 day';
-    if (seconds === 604800) return '1 week';
-    return `${seconds} seconds`;
-  };
+  const maxExpiration = config?.FORCE_EXPIRATION || 604800;
+  const expirationOptions = allExpirationOptions.filter((option) => option.value <= maxExpiration);
+
+  const forceExpirationLabel = allExpirationOptions.find(
+    (option) => option.value === config?.FORCE_EXPIRATION
+  )?.label;
 
   return (
     <>
@@ -53,7 +52,7 @@ export function SecretOptions({
         {config?.FORCE_EXPIRATION && (
           <p className="text-sm text-base-content/70 mb-2">
             {t('expiration.serverEnforcedMessage', {
-              value: getExpirationLabel(config.FORCE_EXPIRATION),
+              value: forceExpirationLabel,
             })}
           </p>
         )}

--- a/website/src/shared/components/SecretOptions.tsx
+++ b/website/src/shared/components/SecretOptions.tsx
@@ -51,26 +51,11 @@ export function SecretOptions({
           </span>
         </label>
         {config?.FORCE_EXPIRATION && (
-          <div className="alert alert-info mb-2">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              className="stroke-current shrink-0 w-6 h-6"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              ></path>
-            </svg>
-            <span>
-              {t('expiration.serverEnforcedMaximumExpiration', {
-                value: getExpirationLabel(config.FORCE_EXPIRATION),
-              })}
-            </span>
-          </div>
+          <p className="text-sm text-base-content/70 mb-2">
+            {t('expiration.serverEnforcedMessage', {
+              value: getExpirationLabel(config.FORCE_EXPIRATION),
+            })}
+          </p>
         )}
         <div className="flex flex-wrap gap-4 mt-2">
           {expirationOptions.map((option, index) => (

--- a/website/src/shared/context/ConfigContext.tsx
+++ b/website/src/shared/context/ConfigContext.tsx
@@ -9,6 +9,7 @@ export interface Config {
   PREFETCH_SECRET: boolean;
   NO_LANGUAGE_SWITCHER: boolean;
   FORCE_ONETIME_SECRETS: boolean;
+  FORCE_EXPIRATION?: number;
   PRIVACY_NOTICE_URL?: string;
   IMPRINT_URL?: string;
 }
@@ -52,6 +53,7 @@ async function loadConfig(): Promise<Config> {
         PREFETCH_SECRET: data.PREFETCH_SECRET,
         NO_LANGUAGE_SWITCHER: data.NO_LANGUAGE_SWITCHER,
         FORCE_ONETIME_SECRETS: data.FORCE_ONETIME_SECRETS,
+        FORCE_EXPIRATION: data.FORCE_EXPIRATION,
         PRIVACY_NOTICE_URL: data.PRIVACY_NOTICE_URL,
         IMPRINT_URL: data.IMPRINT_URL,
       };

--- a/website/src/shared/context/ConfigContext.tsx
+++ b/website/src/shared/context/ConfigContext.tsx
@@ -53,7 +53,7 @@ async function loadConfig(): Promise<Config> {
         PREFETCH_SECRET: data.PREFETCH_SECRET,
         NO_LANGUAGE_SWITCHER: data.NO_LANGUAGE_SWITCHER,
         FORCE_ONETIME_SECRETS: data.FORCE_ONETIME_SECRETS,
-        FORCE_EXPIRATION: data.FORCE_EXPIRATION,
+        FORCE_EXPIRATION: typeof data.FORCE_EXPIRATION === 'number' ? data.FORCE_EXPIRATION : undefined,
         PRIVACY_NOTICE_URL: data.PRIVACY_NOTICE_URL,
         IMPRINT_URL: data.IMPRINT_URL,
       };

--- a/website/src/shared/locales/by.json
+++ b/website/src/shared/locales/by.json
@@ -88,7 +88,8 @@
     "legend": "Будзе аўтаматычна выдалены праз",
     "optionOneHourLabel": "1 гадзіна",
     "optionOneDayLabel": "1 дзень",
-    "optionOneWeekLabel": "1 тыдзень"
+    "optionOneWeekLabel": "1 тыдзень",
+    "serverEnforcedMessage": "Сакрэт аўтаматычна скончыцца праз {{value}}"
   },
   "features": {
     "title": "Дзяліцеся сакрэтамі бяспечна і без лішніх клопатаў",

--- a/website/src/shared/locales/cs.json
+++ b/website/src/shared/locales/cs.json
@@ -88,7 +88,8 @@
     "legend": "Automaticky smazat za",
     "optionOneHourLabel": "Jednu hodinu",
     "optionOneDayLabel": "Jeden den",
-    "optionOneWeekLabel": "Jeden týden"
+    "optionOneWeekLabel": "Jeden týden",
+    "serverEnforcedMessage": "Tajný obsah vyprší automaticky za {{value}}"
   },
   "features": {
     "title": "Sdílejte tajné zprávy snadno a bezpečně",

--- a/website/src/shared/locales/de.json
+++ b/website/src/shared/locales/de.json
@@ -88,7 +88,8 @@
     "legend": "Die verschlüsselte Nachricht wird automatisch gelöscht nach",
     "optionOneHourLabel": "Eine Stunde",
     "optionOneDayLabel": "Ein Tag",
-    "optionOneWeekLabel": "Eine Woche"
+    "optionOneWeekLabel": "Eine Woche",
+    "serverEnforcedMessage": "Das Geheimnis läuft automatisch in {{value}} ab"
   },
   "features": {
     "title": "Geheimnisse sicher und einfach teilen",

--- a/website/src/shared/locales/en.json
+++ b/website/src/shared/locales/en.json
@@ -88,7 +88,8 @@
     "legend": "Deleted automatically after",
     "optionOneHourLabel": "One Hour",
     "optionOneDayLabel": "One Day",
-    "optionOneWeekLabel": "One Week"
+    "optionOneWeekLabel": "One Week",
+    "serverEnforcedMessage": "Secret will expire automatically in {{value}}"
   },
   "features": {
     "title": "Share secrets securely with ease",

--- a/website/src/shared/locales/es.json
+++ b/website/src/shared/locales/es.json
@@ -88,7 +88,8 @@
     "legend": "Se eliminará automáticamente después de",
     "optionOneHourLabel": "Una hora",
     "optionOneDayLabel": "Un día",
-    "optionOneWeekLabel": "Una semana"
+    "optionOneWeekLabel": "Una semana",
+    "serverEnforcedMessage": "El secreto expirará automáticamente en {{value}}"
   },
   "features": {
     "title": "Comparta secretos de forma segura y sencilla",

--- a/website/src/shared/locales/fr.json
+++ b/website/src/shared/locales/fr.json
@@ -107,7 +107,7 @@
   },
   "header": {
     "buttonHome": "Accueil",
-    "buttonUpload": "Télécharger",
+    "buttonUpload": "Téléverser",
     "buttonText": "Texte",
     "appName": "Yopass"
   },

--- a/website/src/shared/locales/fr.json
+++ b/website/src/shared/locales/fr.json
@@ -87,7 +87,8 @@
     "legend": "Le message chiffré sera supprimé automatiquement après",
     "optionOneHourLabel": "Une Heure",
     "optionOneDayLabel": "Un Jour",
-    "optionOneWeekLabel": "Une Semaine"
+    "optionOneWeekLabel": "Une Semaine",
+    "serverEnforcedMessage": "Le secret expirera automatiquement dans {{value}}"
   },
   "features": {
     "title": "Partagez facilement vos secrets de manière sécurisée",

--- a/website/src/shared/locales/nl.json
+++ b/website/src/shared/locales/nl.json
@@ -88,7 +88,8 @@
     "legend": "Automatisch verwijderd na",
     "optionOneHourLabel": "Eén uur",
     "optionOneDayLabel": "Eén dag",
-    "optionOneWeekLabel": "Eén week"
+    "optionOneWeekLabel": "Eén week",
+    "serverEnforcedMessage": "Het geheim verloopt automatisch over {{value}}"
   },
   "features": {
     "title": "Deel geheimen veilig en eenvoudig",

--- a/website/src/shared/locales/no.json
+++ b/website/src/shared/locales/no.json
@@ -88,7 +88,8 @@
     "legend": "Slettes automatisk etter",
     "optionOneHourLabel": "En time",
     "optionOneDayLabel": "En dag",
-    "optionOneWeekLabel": "En uke"
+    "optionOneWeekLabel": "En uke",
+    "serverEnforcedMessage": "Hemmeligheten utløper automatisk om {{value}}"
   },
   "features": {
     "title": "Del hemmeligheter sikkert og enkelt",

--- a/website/src/shared/locales/pl.json
+++ b/website/src/shared/locales/pl.json
@@ -88,7 +88,8 @@
     "legend": "Automatyczne usunięcie wiadomości po",
     "optionOneHourLabel": "1 godzinie",
     "optionOneDayLabel": "1 dniu",
-    "optionOneWeekLabel": "1 tygodniu"
+    "optionOneWeekLabel": "1 tygodniu",
+    "serverEnforcedMessage": "Sekret wygaśnie automatycznie za {{value}}"
   },
   "features": {
     "title": "Udostępniaj sekrety bezpiecznie i łatwo",

--- a/website/src/shared/locales/ru.json
+++ b/website/src/shared/locales/ru.json
@@ -88,7 +88,8 @@
     "legend": "Будет удалён автоматически через",
     "optionOneHourLabel": "1 час",
     "optionOneDayLabel": "1 день",
-    "optionOneWeekLabel": "1 неделю"
+    "optionOneWeekLabel": "1 неделю",
+    "serverEnforcedMessage": "Секрет автоматически истечёт через {{value}}"
   },
   "features": {
     "title": "Делитесь секретами безопасно и без лишних усилий",

--- a/website/src/shared/locales/sv.json
+++ b/website/src/shared/locales/sv.json
@@ -88,7 +88,8 @@
     "legend": "Radera automatiskt efter",
     "optionOneHourLabel": "En timme",
     "optionOneDayLabel": "En dag",
-    "optionOneWeekLabel": "En vecka"
+    "optionOneWeekLabel": "En vecka",
+    "serverEnforcedMessage": "Hemligheten upphör automatiskt om {{value}}"
   },
   "features": {
     "title": "Dela meddelanden säkert med enkelhet",


### PR DESCRIPTION
Based on the [Feature Request](https://github.com/jhaals/yopass/issues/3206) 

## Summary

Adds server-side enforcement of maximum secret expiration time via a new `--force-expiration` flag.

## Motivation

Addresses #3206 - administrators needed a way to enforce organization-wide maximum expiration policies for secrets.

## Changes

- Added `--force-expiration` flag accepting `3600` (1h), `86400` (1d), or `604800` (1w)
- Server validates the flag at startup and fails with clear error if misconfigured
- Client requests exceeding the server maximum are rejected with HTTP 400
- Clients can still choose shorter expirations within the limit
- Frontend automatically hides options exceeding the server maximum
- `/config` endpoint exposes `FORCE_EXPIRATION` for UI awareness

## Usage

```bash
# Enforce maximum 1 hour expiration
yopass-server --force-expiration=3600

# Or via environment variable
FORCE_EXPIRATION=3600 yopass-server

Example: With --force-expiration=3600:

✅ Client requests 1 hour → Accepted
❌ Client requests 1 day → Rejected: "Expiration exceeds server maximum"
Testing
Added comprehensive unit tests for all scenarios
Validated startup error handling with invalid values
Tested UI filtering of unavailable options
