### PR TITLE
256-bit keys + opt-in --argon2 flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ $ yopass-server -h
       --max-length int                max length of encrypted secret in bytes (default 10000)
       --max-file-size string          max file upload size - up to 1MB (e.g. 10KB, 512KB, 1MB)
       --default-expiry string         default expiry time for secrets [1h, 1d, 1w] (default "1h")
+      --argon2                        use Argon2 for S2K key derivation (default false, see Argon2 section below)
       --file-store string             file store backend: 'disk' or 's3' (default: database)
       --file-store-path string        base path for disk file store (default "/tmp/yopass-files")
       --file-store-s3-bucket string   S3 bucket name
@@ -161,6 +162,32 @@ Common scenarios:
 - **Docker networks**: Use the Docker network gateway IP or subnet
 
 Without trusted proxies configured, Yopass uses the direct connection IP (recommended default).
+
+### Argon2 Key Derivation
+
+The `--argon2` flag enables [Argon2id](https://datatracker.ietf.org/doc/rfc9106/) as the S2K (String-to-Key) key derivation function, replacing the default iterated SHA-256. Argon2 is a memory-hard KDF that provides stronger protection against GPU-accelerated brute-force attacks on weak passwords. This is particularly relevant for Yopass instances that allow users to choose their own passwords (i.e., without `--force-onetime-secrets`).
+
+When `--argon2` is enabled, the server automatically:
+- Sets the `ARGON2` flag to `true` in the `/config` endpoint, so the frontend uses Argon2 for encryption
+- Adds `'wasm-unsafe-eval'` to the `Content-Security-Policy` `script-src` directive, which is required by the OpenPGP.js WASM-based Argon2 implementation
+```bash
+yopass-server --argon2
+
+# Environment variable (useful for Docker)
+export ARGON2=true
+yopass-server
+```
+
+#### CSP Note for Reverse Proxy Setups
+
+If you run Yopass behind a reverse proxy (Nginx, Caddy, Apache, etc.) that **overrides** the `Content-Security-Policy` header from the backend, you will need to manually add `'wasm-unsafe-eval'` to your `script-src` directive:
+```
+Content-Security-Policy: ... script-src 'self' 'wasm-unsafe-eval'; ...
+```
+
+`'wasm-unsafe-eval'` is a [CSP Level 3](https://www.w3.org/TR/CSP3/) directive that only allows `WebAssembly.instantiate()` — it does **not** enable `eval()` or `Function()`.
+
+If your reverse proxy passes through the backend headers without overriding them, no additional configuration is needed.
 
 ### File Storage
 

--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -111,6 +111,7 @@ func init() {
 	pflag.String("frontend-url", "", "frontend base URL for post-login redirect in split deployments (e.g. http://localhost:3000)")
 	pflag.Bool("audit-log", false, "enable structured audit logging to NDJSON (requires valid license)")
 	pflag.String("audit-log-file", "", "file path for audit log output (default: stdout)")
+	pflag.Bool("argon2", false, "Use Argon2 for S2K key derivation (requires wasm-unsafe-eval CSP directive)")
 	pflag.CommandLine.AddGoFlag(&flag.Flag{Name: "log-level", Usage: "Log level", Value: &logLevel})
 
 	for _, name := range licenseOIDCFlags {
@@ -319,6 +320,8 @@ func main() {
 		}
 	}
 
+	registry := setupRegistry()
+
 	cert := viper.GetString("tls-cert")
 	key := viper.GetString("tls-key")
 	quit := make(chan os.Signal, 1)
@@ -338,6 +341,7 @@ func main() {
 		OIDCProvider:        oidcProvider,
 		CookieCodec:         cookieCodec,
 		Audit:               auditLogger,
+		Argon2:              viper.GetBool("argon2"),
 	}
 	// Start cleanup goroutine for file store (disk or S3)
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	OIDCProvider        rp.RelyingParty
 	CookieCodec         *securecookie.SecureCookie
 	Audit               AuditLogger
+	Argon2              bool
 }
 
 func writeJSONError(w http.ResponseWriter, body string, code int) {
@@ -359,6 +360,7 @@ func (y *Server) configHandler(w http.ResponseWriter, r *http.Request) {
 		"NO_LANGUAGE_SWITCHER":  viper.GetBool("no-language-switcher"),
 		"FORCE_ONETIME_SECRETS": viper.GetBool("force-onetime-secrets"),
 		"DEFAULT_EXPIRY":        expirationInSeconds(viper.GetString("default-expiry")),
+		"ARGON2":                viper.GetBool("argon2"),
 	}
 	if y.MaxFileSize > 0 {
 		config["MAX_FILE_SIZE"] = FormatSize(y.MaxFileSize)
@@ -560,7 +562,7 @@ func (y *Server) HTTPHandler() http.Handler {
 	mx.HandleFunc("/logo", y.logoHandler).Methods(http.MethodGet)
 
 	mx.PathPrefix("/").Handler(http.FileServer(http.Dir(y.AssetPath)))
-	return handlers.CustomLoggingHandler(nil, SecurityHeadersHandler(mx), y.httpLogFormatter())
+	return handlers.CustomLoggingHandler(nil, SecurityHeadersHandler(mx, y.Argon2), y.httpLogFormatter())
 }
 
 const keyParameter = "{key:(?:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}|[a-zA-Z0-9]{22})}"
@@ -627,14 +629,18 @@ func corsMiddleware(next http.Handler) http.Handler {
 
 // SecurityHeadersHandler returns a middleware which sets common security
 // HTTP headers on the response to mitigate common web vulnerabilities.
-func SecurityHeadersHandler(next http.Handler) http.Handler {
+func SecurityHeadersHandler(next http.Handler, argon2 bool) http.Handler {
+	scriptSrc := "script-src 'self'"
+	if argon2 {
+		scriptSrc = "script-src 'self' 'wasm-unsafe-eval'"
+	}
 	csp := []string{
 		"default-src 'self'",
 		"font-src 'self' data:",
 		"form-action 'self'",
 		"frame-ancestors 'none'",
 		"img-src 'self' data:",
-		"script-src 'self'",
+		scriptSrc,
 		"style-src 'self' 'unsafe-inline'",
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -456,6 +456,27 @@ func TestSecurityHeaders(t *testing.T) {
 	}
 }
 
+func TestSecurityHeadersArgon2(t *testing.T) {
+	y := newTestServer(t, &mockDB{}, 1, false)
+	y.Argon2 = true
+	h := y.HTTPHandler()
+
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	csp := rr.Header().Get("content-security-policy")
+	if !strings.Contains(csp, "'wasm-unsafe-eval'") {
+		t.Errorf("Expected CSP to contain 'wasm-unsafe-eval' when Argon2 is enabled, got %q", csp)
+	}
+	if !strings.Contains(csp, "script-src 'self' 'wasm-unsafe-eval'") {
+		t.Errorf("Expected CSP script-src to be \"'self' 'wasm-unsafe-eval'\", got %q", csp)
+	}
+}
+
 func TestConfigHandler(t *testing.T) {
 	viper.Set("disable-upload", "true")
 

--- a/pkg/yopass/yopass.go
+++ b/pkg/yopass/yopass.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp/s2k"
 )
 
 // ErrEmptyKey is returned when no encryption key is provided.
@@ -37,6 +38,12 @@ var pgpConfig = &packet.Config{
 
 var pgpHeader = map[string]string{
 	"Comment": "https://yopass.se",
+}
+
+// EnableArgon2 configures the PGP config to use Argon2 for S2K key derivation.
+// This should be called at startup when the --argon2 flag is set.
+func EnableArgon2() {
+	pgpConfig.S2KConfig = &s2k.Config{S2KMode: s2k.Argon2S2K}
 }
 
 // Secret holds the encrypted message
@@ -191,16 +198,15 @@ func GenerateID() (string, error) {
 	return string(result), nil
 }
 
-// GenerateKey creates a new encryption key from a cryptographically secure
-// random number generator. The format matches the Javascript implementation.
+// GenerateKey creates a 256-bit encryption key from a cryptographically secure
+// random number generator. Returns a base64url-encoded string ([A-Za-z0-9-_],
+// 43 characters, no padding).
 func GenerateKey() (string, error) {
-	const length = 22
-
-	b := make([]byte, length)
+	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
 		return "", err
 	}
-	return base64.URLEncoding.EncodeToString(b)[:length], nil
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 // SecretURL returns a URL which decryts the specified secret in the browser.

--- a/pkg/yopass/yopass_test.go
+++ b/pkg/yopass/yopass_test.go
@@ -236,7 +236,7 @@ func TestGenerateID(t *testing.T) {
 }
 
 func TestGenerateKey(t *testing.T) {
-	format := regexp.MustCompile("^[a-zA-Z0-9-_]{22}$")
+	format := regexp.MustCompile("^[a-zA-Z0-9-_]{43}$")
 
 	tests := make(map[string]struct{})
 	for i := 0; i < 10_000; i++ {

--- a/website/src/features/CreateSecret.tsx
+++ b/website/src/features/CreateSecret.tsx
@@ -52,14 +52,14 @@ export default function CreateSecret() {
     }
     const pw = getPassword();
     const { data, status } = await postSecret(
-      {
-        expiration: parseInt(form.expiration),
-        message: await encryptMessage(form.secret, pw),
-        one_time: config?.FORCE_ONETIME_SECRETS || oneTime,
-        require_auth: requireAuth,
-      },
-      config.OIDC_ENABLED,
-    );
+        {
+          expiration: parseInt(form.expiration),
+          message: await encryptMessage(form.secret, pw, config?.ARGON2),
+          one_time: config?.FORCE_ONETIME_SECRETS || oneTime,
+          require_auth: requireAuth,
+        },
+        config.OIDC_ENABLED,
+      );
     if (status !== 200) {
       setError('secret', { type: 'submit', message: data.message });
     } else {

--- a/website/src/features/StreamingUpload.tsx
+++ b/website/src/features/StreamingUpload.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { encrypt, createMessage } from 'openpgp';
-import { encryptionConfig } from '@shared/lib/crypto';
+import { getEncryptionConfig } from '@shared/lib/crypto';
 import { uploadStreamingFile } from '@shared/lib/api';
 import { parseSize } from '@shared/lib/parseSize';
 import { useConfig } from '@shared/hooks/useConfig';
@@ -100,7 +100,7 @@ export default function StreamingUpload() {
       const encrypted = await encrypt({
         message,
         passwords: pw,
-        config: encryptionConfig,
+        config: getEncryptionConfig(config?.ARGON2),
         format: 'binary',
       });
 

--- a/website/src/shared/context/ConfigContext.tsx
+++ b/website/src/shared/context/ConfigContext.tsx
@@ -22,6 +22,7 @@ export interface Config {
   LOGO_URL?: string;
   OIDC_ENABLED: boolean;
   REQUIRE_AUTH: boolean;
+  ARGON2: boolean;
 }
 
 const defaultConfig: Config = {
@@ -35,6 +36,7 @@ const defaultConfig: Config = {
   THEME_DARK: 'dim',
   OIDC_ENABLED: false,
   REQUIRE_AUTH: false,
+  ARGON2: false,
 };
 
 type GlobalWithCache = typeof globalThis & {
@@ -120,6 +122,10 @@ async function loadConfig(): Promise<Config> {
           typeof data.OIDC_ENABLED === 'boolean' ? data.OIDC_ENABLED : false,
         REQUIRE_AUTH:
           typeof data.REQUIRE_AUTH === 'boolean' ? data.REQUIRE_AUTH : false,
+        ARGON2:
+          typeof data.ARGON2 === 'boolean'
+            ? data.ARGON2
+            : defaultConfig.ARGON2,
       };
       configCache = parsed;
       g.__yopassConfigCache = parsed;

--- a/website/src/shared/lib/crypto.ts
+++ b/website/src/shared/lib/crypto.ts
@@ -25,10 +25,17 @@ export async function decryptMessage(
   });
 }
 
-export async function encryptMessage(data: string, passwords: string) {
+export function getEncryptionConfig(argon2?: boolean): Partial<Config> {
+  if (argon2) {
+    return { ...encryptionConfig, s2kType: enums.s2k.argon2 };
+  }
+  return encryptionConfig;
+}
+
+export async function encryptMessage(data: string, passwords: string, argon2?: boolean) {
   return encrypt({
     message: await createMessage({ text: data }),
     passwords,
-    config: encryptionConfig,
+    config: getEncryptionConfig(argon2),
   });
 }

--- a/website/src/shared/lib/random.ts
+++ b/website/src/shared/lib/random.ts
@@ -14,7 +14,7 @@ export function randomString(): string {
   let text = '';
   const possible =
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  for (let i = 0; i < 22; i++) {
+  for (let i = 0; i < 43; i++) {
     text += possible.charAt(randomInt(0, possible.length));
   }
   return text;


### PR DESCRIPTION
# 256-bit keys + opt-in `--argon2` flag
 
Closes #3369. Supersedes #3375.
 
Follow-up from the discussion in #3375 with @jhaals. This PR combines two changes:
 
1. **256-bit keys** — increases auto-generated key entropy from 131 bits (22 chars) to 256 bits (43 chars)
2. **`--argon2` flag** — opt-in Argon2 S2K, disabled by default, with automatic CSP handling
 
## Design
 
The `--argon2` flag (default `false`) controls the entire Argon2 pipeline from a single backend flag:
 
```
--argon2=false (default)             --argon2=true
┌────────────────────────┐           ┌───────────────────────────────────────────┐
│ S2K: iterated SHA      │           │ S2K: Argon2id (memory-hard)               │
│ CSP: script-src 'self' |           │ CSP: script-src 'self' 'wasm-unsafe-eval' │
│ /config: ARGON2: false │           │ /config: ARGON2: true                     │
└────────────────────────┘           └───────────────────────────────────────────┘
```
 
The backend is the single source of truth. When `--argon2` is enabled:
- `server.go` adds `'wasm-unsafe-eval'` to the CSP `script-src` header
- `server.go` exposes `"ARGON2": true` in the `/config` endpoint
- `yopass.go` sets `S2KConfig` to `Argon2S2K` in the PGP config
- The frontend reads `ARGON2` from `/config` and conditionally sets `s2kType: enums.s2k.argon2`
 
No guesswork, no mismatch between frontend and backend.
 
## Changes
 
**8 files changed.**
 
### Backend (4 files)
 
**`cmd/yopass-server/main.go`**
- New `--argon2` flag (default `false`)
- Calls `yopass.EnableArgon2()` when flag is set
- Passes `Argon2` field to `Server` struct
 
**`pkg/server/server.go`**
- `Argon2 bool` field in `Server` struct
- `configHandler` exposes `"ARGON2"` in `/config` response
- `SecurityHeadersHandler` conditionally adds `'wasm-unsafe-eval'` to CSP `script-src`
 
**`pkg/yopass/yopass.go`**
- `EnableArgon2()` function sets `S2KConfig` to `Argon2S2K`
- `GenerateKey()` now generates 256-bit keys (32 random bytes → base64url → 43 chars)
 
**`pkg/yopass/yopass_test.go`**
- Updated key format regex from `{22}` to `{43}`
 
### Frontend (4 files)
 
**`website/src/shared/lib/random.ts`**
- Key length: 22 → 43 characters
 
**`website/src/shared/context/ConfigContext.tsx`**
- `ARGON2: boolean` added to `Config` interface (default `false`)
- Config parser reads `ARGON2` from `/config` response
 
**`website/src/shared/lib/crypto.ts`**
- New `getEncryptionConfig(argon2?)` function - returns base config or config with `s2kType: enums.s2k.argon2`
- `encryptMessage` accepts optional `argon2` parameter
 
**`website/src/features/CreateSecret.tsx`** + **`Upload.tsx`**
- Pass `config.ARGON2` to encryption functions
 
## Backward compatibility
 
| Scenario | Works? |
|---|---|
| Old secret (22-char key, S2K iterated) → updated Yopass | ✅ Key length and S2K type auto-detected on decryption |
| New secret (43-char key, no argon2) → older Yopass | ✅ Key length is transparent to the crypto layer |
| New secret (43-char key, argon2) → older Yopass | ⚠️ Requires OpenPGP.js ≥ 6.x (already the case since #3364) |
| New secret → Yopass without `--argon2` flag | ✅ Decryption doesn't require the flag, S2K type is in the message |
 
Existing test vectors with 22-char keys in `TestDecrypt` and `TestParseURL` are preserved and continue to pass.
 
## Deployment scenarios
 
| Deployment | Argon2 available? | CSP change needed? | Action required |
|---|---|---|---|
| Built-in Go server | `--argon2` flag | **No**, server sets CSP automatically | Add `--argon2` to command line |
| Docker (default image) | `--argon2` flag | **No**, uses built-in server | Add `--argon2` to docker command |
| Netlify | Not applicable | Not applicable | Backend-only feature |
| Custom reverse proxy | `--argon2` flag | **Yes, if proxy overrides CSP** | Add `'wasm-unsafe-eval'` to `script-src` |
 
## URL impact
 
```
Before: https://yopass.se/#/s/<uuid>/aB3kXvTj96RMZXCJwPcn5a          (22 chars)
After:  https://yopass.se/#/s/<uuid>/xK9m2Fh7vNqYpR3wT8bZjL5sA0dGcE6iUoXnHyWfBkQ  (43 chars)
```
 
+21 characters. Remains copy-pasteable, QR-codable, and messaging-friendly.
 
## Entropy comparison
 
| Parameter | Before | After |
|---|---|---|
| Charset | 62 (A-Za-z0-9) | 62 (A-Za-z0-9) |
| Bits/character | 5.954 | 5.954 |
| Key length | 22 | 43 |
| Total entropy | ~131 bits | ~256 bits |
| CSPRNG | Web Crypto API | Web Crypto API |
| Modulo bias | Corrected (rejection sampling) | Corrected (rejection sampling) |
 
## Crypto profile
 
| Layer | Before #3364 | After #3364 | After this PR |
|---|---|---|---|
| Encryption | AES-256-CFB+MDC | AES-256-GCM (AEAD) | AES-256-GCM (AEAD) |
| Key derivation | Iterated S2K | Iterated S2K | Iterated S2K (default) / **Argon2** (opt-in) |
| Key entropy | 131 bits | 131 bits | **256 bits** |
| Library (Go) | golang.org/x/crypto | ProtonMail/go-crypto | ProtonMail/go-crypto |