### PR TITLE
Add PUBLIC_URL support for public instance links

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ $ yopass-server -h
       --trusted-proxies strings       trusted proxy IP addresses or CIDR blocks for X-Forwarded-For header validation
       --privacy-notice-url string     URL to privacy notice page
       --imprint-url string            URL to imprint/legal notice page
+      --public-url string             base URL of the public/read-only instance used in generated secret links
       --metrics-port int              metrics server listen port (default -1)
       --health-check                  perform database health check and exit
       --log-level                     log level (debug, info, warn, error)
@@ -219,6 +220,18 @@ yopass-server --read-only
 ```
 
 In this mode, `POST /create/secret` and `POST /create/file` return 404. Retrieval and deletion endpoints remain active.
+
+When using this two-instance setup, tell the creation instance the URL of the public instance so that generated secret links point there instead of the creation instance:
+
+```bash
+# Creation instance (internal, behind authentication)
+yopass-server --public-url https://secrets.example.com
+
+# Public instance (read-only)
+yopass-server --read-only
+```
+
+With `--public-url` set, all secret links displayed after creation will use `https://secrets.example.com` as their base, so recipients are directed to the public instance.
 
 ## Command-Line Interface
 

--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -84,6 +84,7 @@ func init() {
 	pflag.StringSlice("trusted-proxies", []string{}, "trusted proxy IP addresses or CIDR blocks for X-Forwarded-For header validation")
 	pflag.String("privacy-notice-url", "", "URL to privacy notice page")
 	pflag.String("imprint-url", "", "URL to imprint/legal notice page")
+	pflag.String("public-url", "", "base URL of the public/read-only instance used in generated secret links (e.g. https://secrets.example.com)")
 	pflag.String("default-expiry", "1h", "default expiry time for secrets [1h, 1d, 1w]")
 	pflag.String("theme-light", "emerald", "DaisyUI theme name for light mode")
 	pflag.String("theme-dark", "dim", "DaisyUI theme name for dark mode")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -371,6 +371,9 @@ func (y *Server) configHandler(w http.ResponseWriter, r *http.Request) {
 	if imprintURL := viper.GetString("imprint-url"); imprintURL != "" {
 		config["IMPRINT_URL"] = imprintURL
 	}
+	if publicURL := viper.GetString("public-url"); publicURL != "" {
+		config["PUBLIC_URL"] = publicURL
+	}
 	if y.License.Valid {
 		if logoURL := viper.GetString("logo-url"); logoURL != "" {
 			config["LOGO_URL"] = logoURL

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -706,6 +706,68 @@ func TestConfigHandlerPrivacyAndImprint(t *testing.T) {
 	}
 }
 
+func TestConfigHandlerPublicURL(t *testing.T) {
+	tt := []struct {
+		name          string
+		publicURL     string
+		expectPresent bool
+	}{
+		{
+			name:          "no public URL configured",
+			publicURL:     "",
+			expectPresent: false,
+		},
+		{
+			name:          "public URL configured",
+			publicURL:     "https://secrets.example.com",
+			expectPresent: true,
+		},
+		{
+			name:          "public URL with trailing slash",
+			publicURL:     "https://secrets.example.com/",
+			expectPresent: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Reset()
+			viper.Set("public-url", tc.publicURL)
+
+			server := newTestServer(t, &mockDB{}, 1, false)
+
+			req := httptest.NewRequest(http.MethodGet, "/config", nil)
+			w := httptest.NewRecorder()
+			server.configHandler(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+
+			if res.StatusCode != http.StatusOK {
+				t.Fatalf("Expected status OK, got %d", res.StatusCode)
+			}
+
+			var config map[string]interface{}
+			if err := json.NewDecoder(res.Body).Decode(&config); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+
+			val, hasKey := config["PUBLIC_URL"]
+			if tc.expectPresent {
+				if !hasKey {
+					t.Error("Expected PUBLIC_URL key to exist in config response")
+				} else if val.(string) != tc.publicURL {
+					t.Errorf("Expected PUBLIC_URL to be %q, got %q", tc.publicURL, val)
+				}
+			} else {
+				if hasKey {
+					t.Errorf("Expected PUBLIC_URL key to not exist in config response, but got %v", val)
+				}
+			}
+		})
+	}
+}
+
 func TestDisableUploadRoutes(t *testing.T) {
 	// Test with uploads disabled
 	viper.Set("disable-upload", true)

--- a/website/src/features/display-secret/Result.tsx
+++ b/website/src/features/display-secret/Result.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useConfig } from '@shared/hooks/useConfig';
 interface ResultProps {
   password: string;
   uuid: string;
@@ -71,8 +72,12 @@ function Result({
   oneTime,
 }: ResultProps) {
   const { t } = useTranslation();
-  const oneClickLink = `${window.location.origin}/#/${prefix}/${uuid}/${password}`;
-  const shortLink = `${window.location.origin}/#/${prefix}/${uuid}`;
+  const config = useConfig();
+  const baseURL = config.PUBLIC_URL
+    ? config.PUBLIC_URL.replace(/\/$/, '')
+    : window.location.origin;
+  const oneClickLink = `${baseURL}/#/${prefix}/${uuid}/${password}`;
+  const shortLink = `${baseURL}/#/${prefix}/${uuid}`;
   const [copiedOneClick, setCopiedOneClick] = useState(false);
   const [copiedShortLink, setCopiedShortLink] = useState(false);
   const [copiedPassword, setCopiedPassword] = useState(false);

--- a/website/src/shared/context/ConfigContext.tsx
+++ b/website/src/shared/context/ConfigContext.tsx
@@ -20,6 +20,7 @@ export interface Config {
   THEME_CUSTOM_DARK?: Record<string, string>;
   APP_NAME?: string;
   LOGO_URL?: string;
+  PUBLIC_URL?: string;
   OIDC_ENABLED: boolean;
   REQUIRE_AUTH: boolean;
 }
@@ -115,6 +116,10 @@ async function loadConfig(): Promise<Config> {
         LOGO_URL:
           typeof data.LOGO_URL === 'string' && data.LOGO_URL
             ? data.LOGO_URL
+            : undefined,
+        PUBLIC_URL:
+          typeof data.PUBLIC_URL === 'string' && data.PUBLIC_URL
+            ? data.PUBLIC_URL
             : undefined,
         OIDC_ENABLED:
           typeof data.OIDC_ENABLED === 'boolean' ? data.OIDC_ENABLED : false,

--- a/website/tests/helpers/mock-api.ts
+++ b/website/tests/helpers/mock-api.ts
@@ -199,6 +199,7 @@ export class MockAPI {
     THEME_CUSTOM_LIGHT?: Record<string, string>;
     THEME_CUSTOM_DARK?: Record<string, string>;
     APP_NAME?: string;
+    PUBLIC_URL?: string;
   }) {
     const defaultConfig = {
       DISABLE_UPLOAD: false,

--- a/website/tests/public-url.spec.ts
+++ b/website/tests/public-url.spec.ts
@@ -38,7 +38,8 @@ test.describe('Public URL', () => {
     const linkCode = page.locator('code').first();
     await expect(linkCode).toBeVisible();
     const url = await linkCode.textContent();
-    expect(url).toMatch(new RegExp(`^${publicURL}/#/s/`));
+    const escapedURL = publicURL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    expect(url).toMatch(new RegExp(`^${escapedURL}/#/s/`));
   });
 
   test('should use PUBLIC_URL with trailing slash correctly (no double slash)', async ({

--- a/website/tests/public-url.spec.ts
+++ b/website/tests/public-url.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+import { MockAPI } from './helpers/mock-api';
+import { testSecrets, mockResponses } from './helpers/test-data';
+
+test.describe('Public URL', () => {
+  let mockAPI: MockAPI;
+
+  test.beforeEach(async ({ page }) => {
+    mockAPI = new MockAPI(page);
+  });
+
+  test.afterEach(async () => {
+    await mockAPI.clearAllMocks();
+  });
+
+  test('should use PUBLIC_URL as base for generated secret links', async ({
+    page,
+  }) => {
+    const publicURL = 'https://secrets.example.com';
+
+    await mockAPI.mockConfigEndpoint({ PUBLIC_URL: publicURL });
+    await mockAPI.mockCreateSecret(mockResponses.secretCreated);
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await page.fill(
+      'textarea[placeholder="Enter your secret..."]',
+      testSecrets.simple.message,
+    );
+    await page.click('button[type="submit"]');
+
+    await expect(
+      page.locator('h2:has-text("Secret stored securely")'),
+    ).toBeVisible();
+
+    // The one-click link should use the public URL as its base
+    const linkCode = page.locator('code').first();
+    await expect(linkCode).toBeVisible();
+    const url = await linkCode.textContent();
+    expect(url).toMatch(new RegExp(`^${publicURL}/#/s/`));
+  });
+
+  test('should use PUBLIC_URL with trailing slash correctly (no double slash)', async ({
+    page,
+  }) => {
+    const publicURL = 'https://secrets.example.com/';
+
+    await mockAPI.mockConfigEndpoint({ PUBLIC_URL: publicURL });
+    await mockAPI.mockCreateSecret(mockResponses.secretCreated);
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await page.fill(
+      'textarea[placeholder="Enter your secret..."]',
+      testSecrets.simple.message,
+    );
+    await page.click('button[type="submit"]');
+
+    await expect(
+      page.locator('h2:has-text("Secret stored securely")'),
+    ).toBeVisible();
+
+    // Trailing slash on PUBLIC_URL should not produce double slash in the URL
+    const linkCode = page.locator('code').first();
+    await expect(linkCode).toBeVisible();
+    const url = await linkCode.textContent();
+    expect(url).not.toContain('//#/');
+    expect(url).toMatch(/^https:\/\/secrets\.example\.com\/#\/s\//);
+  });
+
+  test('should fall back to window.location.origin when PUBLIC_URL is not set', async ({
+    page,
+  }) => {
+    await mockAPI.mockConfigEndpoint(); // No PUBLIC_URL
+    await mockAPI.mockCreateSecret(mockResponses.secretCreated);
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await page.fill(
+      'textarea[placeholder="Enter your secret..."]',
+      testSecrets.simple.message,
+    );
+    await page.click('button[type="submit"]');
+
+    await expect(
+      page.locator('h2:has-text("Secret stored securely")'),
+    ).toBeVisible();
+
+    // Without PUBLIC_URL the link should use the current origin (localhost in tests)
+    const linkCode = page.locator('code').first();
+    await expect(linkCode).toBeVisible();
+    const url = await linkCode.textContent();
+    expect(url).toMatch(/^http:\/\/localhost/);
+    expect(url).toContain('/#/s/');
+  });
+});

--- a/website/tests/public-url.spec.ts
+++ b/website/tests/public-url.spec.ts
@@ -38,8 +38,7 @@ test.describe('Public URL', () => {
     const linkCode = page.locator('code').first();
     await expect(linkCode).toBeVisible();
     const url = await linkCode.textContent();
-    const escapedURL = publicURL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    expect(url).toMatch(new RegExp(`^${escapedURL}/#/s/`));
+    expect(url?.startsWith(`${publicURL}/#/s/`)).toBe(true);
   });
 
   test('should use PUBLIC_URL with trailing slash correctly (no double slash)', async ({


### PR DESCRIPTION
This pull request introduces support for a new `--public-url` configuration option, allowing the server to generate secret links that point to a designated public/read-only instance. This is particularly useful in multi-instance deployments where secret creation and retrieval are separated for security reasons. The change is implemented end-to-end: from backend configuration and API, through frontend consumption, to thorough testing and documentation.

**Backend changes:**

* Added a new `--public-url` flag to `yopass-server`, which specifies the base URL for generated secret links in multi-instance setups. This value is exposed via the `/config` API endpoint as `PUBLIC_URL`.
* Added tests to ensure the `PUBLIC_URL` config is correctly handled and exposed by the server.

**Frontend changes:**

* Updated the React app to read `PUBLIC_URL` from the server config and use it as the base for generated secret links; falls back to `window.location.origin` if not set, and ensures no double slashes if a trailing slash is present.
* Updated test helpers to support mocking the `PUBLIC_URL` config.

**Testing and documentation:**

* Added Playwright end-to-end tests to verify that secret links are generated with the correct base URL depending on the presence and format of `PUBLIC_URL`.
* Updated documentation to describe the new flag and its usage in multi-instance (read-only/public) deployments.

These changes make it easier and safer to operate yopass in environments with separate creation and public access instances.