### PR TITLE
docs: fix premium feature links on overview page

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -101,13 +101,13 @@ The following features require a valid `--license-key`. See [pricing](https://yo
 
 | Feature | Docs |
 |---------|------|
-| OpenID Connect authentication | [openid-connect](./openid-connect) |
-| Custom theming & branding | [theming](./theming) |
-| Audit logging | [audit-logging](./audit-logging) |
-| Secret requests | [secret-requests](./secret-requests) |
-| Read receipts | [read-receipts](./read-receipts) |
-| Webhooks | [webhooks](./webhooks) |
-| Increased file size limit (&gt;1 MB) | [file-storage](./file-storage) |
+| OpenID Connect authentication | [openid-connect](./openid-connect.md) |
+| Custom theming & branding | [theming](./theming.md) |
+| Audit logging | [audit-logging](./audit-logging.md) |
+| Secret requests | [secret-requests](./secret-requests.md) |
+| Read receipts | [read-receipts](./read-receipts.md) |
+| Webhooks | [webhooks](./webhooks.md) |
+| Increased file size limit (&gt;1 MB) | [file-storage](./file-storage.md) |
 
 ## Resources
 


### PR DESCRIPTION
Use explicit .md extensions for the relative links in the Premium
features table on the overview page. Extensionless relative links
(e.g. ./openid-connect) are not processed by Docusaurus' Markdown
link resolution: they can resolve incorrectly under trailing-slash
rendering and, more importantly, bypass build-time validation.

With .md targets the links resolve reliably in both dev and
production and are validated at compile time, so onBrokenLinks /
onBrokenMarkdownLinks ("throw") now fail the microsite build if a
target doc is renamed or removed.