### PR TITLE
fix(yopass-server): honor LOG_LEVEL and TRUSTED_PROXIES env vars

### DIFF
--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -365,7 +365,7 @@ func main() {
 		ForceOneTimeSecrets: viper.GetBool("force-onetime-secrets"),
 		AssetPath:           viper.GetString("asset-path"),
 		Logger:              logger,
-		TrustedProxies:      viper.GetStringSlice("trusted-proxies"),
+		TrustedProxies:      getStringSliceCSV("trusted-proxies"),
 		Version:             version,
 		License:             licenseStatus,
 		OIDCProvider:        oidcProvider,
@@ -382,7 +382,7 @@ func main() {
 		DisableReadReceipts:   viper.GetBool("disable-read-receipts"),
 
 		RequireAuth:         viper.GetBool("require-auth"),
-		AllowedEmailDomains: viper.GetStringSlice("oidc-allowed-domains"),
+		AllowedEmailDomains: getStringSliceCSV("oidc-allowed-domains"),
 
 		CORSAllowOrigin:  viper.GetString("cors-allow-origin"),
 		FrontendURL:      viper.GetString("frontend-url"),
@@ -480,6 +480,24 @@ func metricsHandler(r *prometheus.Registry) http.Handler {
 	return mx
 }
 
+// getStringSliceCSV resolves a StringSlice setting consistently across flags,
+// environment variables, and config files. viper only splits command-line flag
+// values on commas; values coming from AutomaticEnv are returned as a single
+// raw string (and cast splits on whitespace, not commas). This helper splits
+// every element on commas and trims whitespace so that, for example,
+// TRUSTED_PROXIES=192.168.1.0/24,10.0.0.0/8 yields two entries.
+func getStringSliceCSV(key string) []string {
+	var out []string
+	for _, v := range viper.GetStringSlice(key) {
+		for _, part := range strings.Split(v, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
+}
+
 func setupRegistry() *prometheus.Registry {
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
@@ -487,10 +505,20 @@ func setupRegistry() *prometheus.Registry {
 	return registry
 }
 
-// configureZapLogger uses the `log-level` command line argument to set and replace the zap global logger.
+// configureZapLogger resolves the log level through viper so that the
+// `log-level` flag, the `LOG_LEVEL` environment variable, and config files are
+// all honored, then sets and replaces the zap global logger.
 func configureZapLogger() *zap.Logger {
 	loggerCfg := zap.NewProductionConfig()
-	loggerCfg.Level.SetLevel(logLevel)
+	if raw := viper.GetString("log-level"); raw != "" {
+		level, err := zapcore.ParseLevel(raw)
+		if err != nil {
+			log.Fatalf("invalid log level %q: %v", raw, err)
+		}
+		loggerCfg.Level.SetLevel(level)
+	} else {
+		loggerCfg.Level.SetLevel(logLevel)
+	}
 
 	logger, err := loggerCfg.Build()
 	if err != nil {

--- a/cmd/yopass-server/main_test.go
+++ b/cmd/yopass-server/main_test.go
@@ -257,6 +257,91 @@ func TestConfigureZapLogger(t *testing.T) {
 	}
 }
 
+func TestConfigureZapLoggerLogLevel(t *testing.T) {
+	tests := []struct {
+		name      string
+		logLevel  string
+		debugWant bool
+	}{
+		{name: "default empty stays info", logLevel: "", debugWant: false},
+		{name: "info level", logLevel: "info", debugWant: false},
+		{name: "debug level via LOG_LEVEL", logLevel: "debug", debugWant: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			viper.Set("log-level", tt.logLevel)
+			defer viper.Reset()
+
+			logger := configureZapLogger()
+			if logger == nil {
+				t.Fatal("Expected non-nil logger")
+			}
+			if got := logger.Core().Enabled(zapcore.DebugLevel); got != tt.debugWant {
+				t.Errorf("debug enabled: got %v, want %v", got, tt.debugWant)
+			}
+		})
+	}
+}
+
+func TestGetStringSliceCSV(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  []string
+	}{
+		{
+			name:  "comma-separated env string is split",
+			value: "192.168.1.0/24,10.0.0.0/8",
+			want:  []string{"192.168.1.0/24", "10.0.0.0/8"},
+		},
+		{
+			name:  "single value without comma",
+			value: "127.0.0.0/8",
+			want:  []string{"127.0.0.0/8"},
+		},
+		{
+			name:  "whitespace around values is trimmed",
+			value: "corp.example.com, example.com",
+			want:  []string{"corp.example.com", "example.com"},
+		},
+		{
+			name:  "already-split slice from flag parsing",
+			value: []string{"127.0.0.0/8", "::1/128"},
+			want:  []string{"127.0.0.0/8", "::1/128"},
+		},
+		{
+			name:  "empty entries are dropped",
+			value: "a,,b, ,c",
+			want:  []string{"a", "b", "c"},
+		},
+		{
+			name:  "empty value yields nil",
+			value: "",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			viper.Set("trusted-proxies", tt.value)
+			defer viper.Reset()
+
+			got := getStringSliceCSV("trusted-proxies")
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("element %d: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestListenAndServe(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Two independent bugs caused environment variables documented in
docs/server-options.md to be silently ignored:

1. LOG_LEVEL: configureZapLogger() read the package-level `logLevel`
   variable directly, which is only populated by pflag.Parse() when the
   --log-level flag is passed on the command line. The bound env var was
   never consumed. Resolve the level through viper instead so the flag,
   LOG_LEVEL, and config files are all honored.

2. TRUSTED_PROXIES (and the latent OIDC_ALLOWED_DOMAINS): these are
   StringSlice settings read via viper.GetStringSlice(). viper only
   comma-splits command-line flag values; AutomaticEnv returns the raw
   string and cast splits on whitespace, so TRUSTED_PROXIES=a,b became
   the single element ["a,b"] and never matched in isTrustedProxy. Add a
   comma-aware helper so flag, env, and config values parse identically.

Adds tests covering both fixes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NE93YzhmANjkV9irZJHmjf