### PR TITLE
Skip server lookups for terminal requests and receipts

### DIFF
--- a/website/src/features/display-secret/ReceiptStatus.tsx
+++ b/website/src/features/display-secret/ReceiptStatus.tsx
@@ -47,7 +47,8 @@ export default function ReceiptStatus({ uuid, token }: ReceiptStatusProps) {
 
   useEffect(() => {
     const initial = setTimeout(refresh, 0);
-    if (viewed) {
+    // Both viewed and expired are terminal: stop polling once either holds.
+    if (viewed || expired) {
       return () => clearTimeout(initial);
     }
     const timer = setInterval(refresh, POLL_INTERVAL_MS);
@@ -55,7 +56,7 @@ export default function ReceiptStatus({ uuid, token }: ReceiptStatusProps) {
       clearTimeout(initial);
       clearInterval(timer);
     };
-  }, [refresh, viewed]);
+  }, [refresh, viewed, expired]);
 
   let statusContent: React.ReactNode;
   if (viewed) {

--- a/website/src/features/display-secret/ReceiptStatus.tsx
+++ b/website/src/features/display-secret/ReceiptStatus.tsx
@@ -46,11 +46,10 @@ export default function ReceiptStatus({ uuid, token }: ReceiptStatusProps) {
   const viewed = receipt?.state === 'viewed';
 
   useEffect(() => {
+    // Both viewed and expired are terminal: don't schedule any refresh once
+    // either holds, so no extra request fires after reaching that state.
+    if (viewed || expired) return;
     const initial = setTimeout(refresh, 0);
-    // Both viewed and expired are terminal: stop polling once either holds.
-    if (viewed || expired) {
-      return () => clearTimeout(initial);
-    }
     const timer = setInterval(refresh, POLL_INTERVAL_MS);
     return () => {
       clearTimeout(initial);

--- a/website/src/features/receipts/ReceiptList.tsx
+++ b/website/src/features/receipts/ReceiptList.tsx
@@ -54,6 +54,15 @@ export default function ReceiptList() {
     setReceipts(stored);
     const results = await Promise.all(
       stored.map(async (r): Promise<[string, ReceiptDisplay]> => {
+        // Terminal states never change, so resolve them locally without a
+        // server lookup. A viewed receipt stays viewed; an expired one only
+        // ever 404s on the server.
+        if (r.state === 'viewed') {
+          return [r.id, { status: 'viewed', viewedAt: r.viewedAt }];
+        }
+        if (Date.now() / 1000 > r.expiresAt) {
+          return [r.id, { status: 'expired' }];
+        }
         const { data, status } = await getSecretReceipt(r.id, r.token);
         if (data) {
           // Cache the observed state so "opened at ..." survives the
@@ -62,11 +71,8 @@ export default function ReceiptList() {
           return [r.id, { status: data.state, viewedAt: data.viewed_at }];
         }
         if (status === 404) {
-          // The receipt expired on the server. The locally cached state
-          // still tells whether the secret was opened in time.
-          if (r.state === 'viewed') {
-            return [r.id, { status: 'viewed', viewedAt: r.viewedAt }];
-          }
+          // The receipt expired on the server before it was ever viewed
+          // (viewed receipts are resolved from the local cache above).
           return [r.id, { status: 'expired' }];
         }
         return [r.id, { status: 'loading' }];

--- a/website/src/features/request-secret/useStoredRequests.ts
+++ b/website/src/features/request-secret/useStoredRequests.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { getSecretRequest } from '@shared/lib/api';
 import {
   listStoredRequests,
-  updateStoredRequest,
+  markRequestsFulfilled,
   REQUESTS_CHANGED_EVENT,
   type StoredRequest,
 } from '@shared/lib/requestStore';
@@ -21,6 +21,7 @@ export function useStoredRequests() {
     const gen = ++refreshGen.current;
     const stored = listStoredRequests();
     setRequests(stored);
+    const freshlyFulfilled: string[] = [];
     const results = await Promise.all(
       stored.map(async (r): Promise<[string, RequestStatus]> => {
         if (r.collected) return [r.id, 'collected'];
@@ -32,9 +33,7 @@ export function useStoredRequests() {
         if (r.fulfilled) return [r.id, 'fulfilled'];
         const { data, status } = await getSecretRequest(r.id);
         if (data) {
-          if (data.state === 'fulfilled') {
-            updateStoredRequest(r.id, { fulfilled: true });
-          }
+          if (data.state === 'fulfilled') freshlyFulfilled.push(r.id);
           return [r.id, data.state];
         }
         if (status === 404) {
@@ -44,9 +43,13 @@ export function useStoredRequests() {
         return [r.id, 'loading'];
       }),
     );
-    if (gen === refreshGen.current) {
-      setStatuses(Object.fromEntries(results));
-    }
+    // Drop a refresh that a newer one has superseded, so overlapped runs
+    // neither clobber fresher statuses nor write to the store. Cache the
+    // fulfilled flags once, after every lookup resolved, so the resulting
+    // REQUESTS_CHANGED_EVENT can't re-enter this refresh mid-flight.
+    if (gen !== refreshGen.current) return;
+    markRequestsFulfilled(freshlyFulfilled);
+    setStatuses(Object.fromEntries(results));
   }, []);
 
   useEffect(() => {

--- a/website/src/features/request-secret/useStoredRequests.ts
+++ b/website/src/features/request-secret/useStoredRequests.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { getSecretRequest } from '@shared/lib/api';
 import {
   listStoredRequests,
+  updateStoredRequest,
   REQUESTS_CHANGED_EVENT,
   type StoredRequest,
 } from '@shared/lib/requestStore';
@@ -24,8 +25,18 @@ export function useStoredRequests() {
       stored.map(async (r): Promise<[string, RequestStatus]> => {
         if (r.collected) return [r.id, 'collected'];
         if (r.revoked) return [r.id, 'revoked'];
+        // Terminal states are resolved locally, without a server lookup.
+        // Expiry wins over a cached fulfilled state: once the TTL passes the
+        // server has deleted the secret, so it can no longer be collected.
+        if (Date.now() / 1000 > r.expiresAt) return [r.id, 'expired'];
+        if (r.fulfilled) return [r.id, 'fulfilled'];
         const { data, status } = await getSecretRequest(r.id);
-        if (data) return [r.id, data.state];
+        if (data) {
+          if (data.state === 'fulfilled') {
+            updateStoredRequest(r.id, { fulfilled: true });
+          }
+          return [r.id, data.state];
+        }
         if (status === 404) {
           const expired = Date.now() / 1000 > r.expiresAt;
           return [r.id, expired ? 'expired' : 'revoked'];

--- a/website/src/shared/lib/requestStatus.ts
+++ b/website/src/shared/lib/requestStatus.ts
@@ -1,18 +1,26 @@
 import { getSecretRequest } from './api';
-import { listStoredRequests } from './requestStore';
+import { listStoredRequests, updateStoredRequest } from './requestStore';
 
 // Counts stored requests whose secret has been provided but not yet
-// collected. Used for the navbar notification badge.
+// collected. Used for the navbar notification badge. Requests already known
+// to be fulfilled are counted from the local cache, so only still-pending
+// requests trigger a server lookup.
 export async function countFulfilledRequests(): Promise<number> {
   const live = listStoredRequests().filter(
     r => !r.collected && !r.revoked && Date.now() / 1000 < r.expiresAt,
   );
-  if (live.length === 0) return 0;
+  const knownFulfilled = live.filter(r => r.fulfilled).length;
+  const pending = live.filter(r => !r.fulfilled);
+  if (pending.length === 0) return knownFulfilled;
   const states = await Promise.all(
-    live.map(async r => {
+    pending.map(async r => {
       const { data } = await getSecretRequest(r.id);
-      return data?.state === 'fulfilled' ? 1 : 0;
+      if (data?.state === 'fulfilled') {
+        updateStoredRequest(r.id, { fulfilled: true });
+        return 1;
+      }
+      return 0;
     }),
   );
-  return states.reduce<number>((sum, n) => sum + n, 0);
+  return knownFulfilled + states.reduce<number>((sum, n) => sum + n, 0);
 }

--- a/website/src/shared/lib/requestStatus.ts
+++ b/website/src/shared/lib/requestStatus.ts
@@ -1,5 +1,5 @@
 import { getSecretRequest } from './api';
-import { listStoredRequests, updateStoredRequest } from './requestStore';
+import { listStoredRequests, markRequestsFulfilled } from './requestStore';
 
 // Counts stored requests whose secret has been provided but not yet
 // collected. Used for the navbar notification badge. Requests already known
@@ -12,15 +12,15 @@ export async function countFulfilledRequests(): Promise<number> {
   const knownFulfilled = live.filter(r => r.fulfilled).length;
   const pending = live.filter(r => !r.fulfilled);
   if (pending.length === 0) return knownFulfilled;
-  const states = await Promise.all(
+  const results = await Promise.all(
     pending.map(async r => {
       const { data } = await getSecretRequest(r.id);
-      if (data?.state === 'fulfilled') {
-        updateStoredRequest(r.id, { fulfilled: true });
-        return 1;
-      }
-      return 0;
+      return data?.state === 'fulfilled' ? r.id : null;
     }),
   );
-  return knownFulfilled + states.reduce<number>((sum, n) => sum + n, 0);
+  const nowFulfilled = results.filter((id): id is string => id !== null);
+  // Cache the newly observed fulfilled states in a single write, after every
+  // lookup has resolved, so the change event can't re-enter this poll mid-call.
+  markRequestsFulfilled(nowFulfilled);
+  return knownFulfilled + nowFulfilled.length;
 }

--- a/website/src/shared/lib/requestStore.ts
+++ b/website/src/shared/lib/requestStore.ts
@@ -53,6 +53,18 @@ export function updateStoredRequest(id: string, patch: Partial<StoredRequest>) {
   );
 }
 
+// Caches the fulfilled terminal state for the given requests in a single
+// write. Pollers that discover several fulfilled requests in one pass use this
+// so only one REQUESTS_CHANGED_EVENT is emitted (and none when nothing
+// changed), which keeps the change event from re-entering an in-flight poll.
+export function markRequestsFulfilled(ids: string[]) {
+  if (ids.length === 0) return;
+  const mark = new Set(ids);
+  const requests = listStoredRequests();
+  if (!requests.some(r => mark.has(r.id) && !r.fulfilled)) return;
+  persist(requests.map(r => (mark.has(r.id) ? { ...r, fulfilled: true } : r)));
+}
+
 export function removeStoredRequest(id: string) {
   persist(listStoredRequests().filter(r => r.id !== id));
 }

--- a/website/src/shared/lib/requestStore.ts
+++ b/website/src/shared/lib/requestStore.ts
@@ -13,6 +13,9 @@ export interface StoredRequest {
   expiresAt: number;
   revoked?: boolean;
   collected?: boolean;
+  // Local cache of the terminal fulfilled state, so the navbar and request
+  // list can stop polling a request once its secret has been provided.
+  fulfilled?: boolean;
 }
 
 const STORAGE_KEY = 'yopass-secret-requests';
@@ -87,6 +90,7 @@ export function importStoredRequest(json: string): StoredRequest {
     expiresAt: parsed.expiresAt,
     revoked: parsed.revoked,
     collected: parsed.collected,
+    fulfilled: parsed.fulfilled,
   };
   saveStoredRequest(request);
   return request;

--- a/website/src/shared/lib/requestStore.ts
+++ b/website/src/shared/lib/requestStore.ts
@@ -102,7 +102,7 @@ export function importStoredRequest(json: string): StoredRequest {
     expiresAt: parsed.expiresAt,
     revoked: parsed.revoked,
     collected: parsed.collected,
-    fulfilled: parsed.fulfilled,
+    fulfilled: typeof parsed.fulfilled === 'boolean' ? parsed.fulfilled : undefined,
   };
   saveStoredRequest(request);
   return request;

--- a/website/src/shared/lib/requestStore.ts
+++ b/website/src/shared/lib/requestStore.ts
@@ -102,7 +102,8 @@ export function importStoredRequest(json: string): StoredRequest {
     expiresAt: parsed.expiresAt,
     revoked: parsed.revoked,
     collected: parsed.collected,
-    fulfilled: typeof parsed.fulfilled === 'boolean' ? parsed.fulfilled : undefined,
+    fulfilled:
+      typeof parsed.fulfilled === 'boolean' ? parsed.fulfilled : undefined,
   };
   saveStoredRequest(request);
   return request;


### PR DESCRIPTION
Resolve terminal states locally instead of polling the server:

- Secret requests: expired and cached-fulfilled requests are resolved from localStorage without a GET /request/{id}; the navbar badge counts fulfilled requests from the local cache and only polls still-pending ones. Expiry takes precedence over a cached fulfilled state.
- Read receipts: the receipts list skips lookups for receipts already viewed or past their expiry, and the result-page panel stops polling once the receipt is expired (not just once viewed).

Cuts recurring 404/no-op traffic for requests and receipts that can no longer change state.