### PR TITLE
Support machine-to-machine authentication

### DIFF
--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -45,6 +45,7 @@ var licenseFlagSections = []struct {
 	{"Authentication / OIDC", "oidc", []string{
 		"oidc-issuer", "oidc-client-id", "oidc-client-secret", "oidc-redirect-url",
 		"require-auth", "oidc-session-key", "oidc-allowed-domains", "frontend-url",
+		"api-token",
 	}},
 	{"Branding & Theming", "branding", []string{
 		"license-key", "app-name", "logo-url",
@@ -122,6 +123,7 @@ func init() {
 	pflag.Bool("require-auth", false, "require authentication to create secrets (needs --oidc-issuer and a valid license)")
 	pflag.String("oidc-session-key", "", "64-byte hex-encoded session key for multi-instance deployments (generate with: openssl rand -hex 64)")
 	pflag.StringSlice("oidc-allowed-domains", []string{}, "restrict secret creation to users whose email matches one of these domains (comma-separated, e.g. corp.example.com,example.com)")
+	pflag.StringSlice("api-token", []string{}, "static bearer token granting machine clients access to the --require-auth gated creation endpoints, formatted as name:secret (comma-separated for multiple; generate secrets with: openssl rand -hex 32)")
 	pflag.String("frontend-url", "", "frontend base URL for post-login redirect in split deployments (e.g. http://localhost:3000)")
 	pflag.Bool("audit-log", false, "enable structured audit logging to NDJSON (requires valid license)")
 	pflag.String("audit-log-file", "", "file path for audit log output (default: stdout)")
@@ -268,6 +270,21 @@ func main() {
 		logger.Fatal("--require-auth is set but OIDC is not configured (check --oidc-issuer and --license-key)")
 	}
 
+	apiTokens, err := server.ParseAPITokens(getStringSliceCSV("api-token"))
+	if err != nil {
+		logger.Fatal("invalid --api-token", zap.Error(err))
+	}
+	if len(apiTokens) > 0 {
+		if !viper.GetBool("require-auth") {
+			logger.Fatal("--api-token is set but --require-auth is not — API tokens only apply when creation requires authentication")
+		}
+		names := make([]string, len(apiTokens))
+		for i, t := range apiTokens {
+			names[i] = t.Name
+		}
+		logger.Info("API token authentication enabled", zap.Strings("tokens", names))
+	}
+
 	var cookieCodec *securecookie.SecureCookie
 	if oidcProvider != nil {
 		sessionKey := viper.GetString("oidc-session-key")
@@ -383,6 +400,7 @@ func main() {
 
 		RequireAuth:         viper.GetBool("require-auth"),
 		AllowedEmailDomains: getStringSliceCSV("oidc-allowed-domains"),
+		APITokens:           apiTokens,
 
 		CORSAllowOrigin:  viper.GetString("cors-allow-origin"),
 		FrontendURL:      viper.GetString("frontend-url"),

--- a/docs/openid-connect.md
+++ b/docs/openid-connect.md
@@ -34,6 +34,7 @@ Yopass supports OpenID Connect for user authentication. When configured, a **Sig
 | `--require-auth` | `REQUIRE_AUTH` | `false` | Reject secret creation requests from unauthenticated users |
 | `--oidc-session-key` | `OIDC_SESSION_KEY` | — | 64-byte hex session key (see [Multi-instance](#multi-instance-deployments)) |
 | `--oidc-allowed-domains` | `OIDC_ALLOWED_DOMAINS` | — | Restrict creation to users with these email domains, comma-separated (e.g. `corp.example.com,example.com`) |
+| `--api-token` | `API_TOKEN` | — | Static bearer token(s) for machine clients, formatted as `name:secret` (see [Machine-to-machine](#machine-to-machine-api-tokens)) |
 
 All three of `--oidc-issuer`, `--oidc-client-id`, and `--oidc-redirect-url` are required to enable OIDC.
 
@@ -119,6 +120,40 @@ yopass-server \
 - The check is case-insensitive (`Example.COM` matches `example.com`).
 - Secret **retrieval** is never gated by email domain — anyone with a valid link can open a secret.
 - If `--oidc-allowed-domains` is set without `--require-auth` it has no effect, because the domain check only runs inside the auth middleware.
+
+---
+
+## Machine-to-machine API tokens
+
+`--require-auth` gates secret creation on the interactive OIDC browser flow, which backend services and automation cannot complete. Use `--api-token` to give such clients a static bearer token instead:
+
+```bash
+# Generate a strong secret (minimum 16 characters enforced)
+openssl rand -hex 32
+
+yopass-server \
+  --require-auth \
+  --api-token "cmdb:4f6a…9c2e" \
+  # … other OIDC flags
+```
+
+Multiple tokens are configured as a comma-separated list (`cmdb:secret1,ops:secret2`) or via the `API_TOKEN` environment variable. Each token has a name so audit logs record which service acted: creations authenticated by a token are attributed as `service:<name>` (e.g. `service:cmdb`).
+
+The client sends the secret in the `Authorization` header:
+
+```bash
+curl https://yopass.example.com/create/secret \
+  -H "Authorization: Bearer 4f6a…9c2e" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"-----BEGIN PGP MESSAGE-----…","expiration":3600,"one_time":true}'
+```
+
+Notes:
+
+- API tokens grant access to the creation endpoints only (`/create/secret`, `/create/file`, and `/request`). Retrieving a secret marked *require authentication* still demands an interactive session.
+- Tokens are service accounts, so `--oidc-allowed-domains` does not apply to them.
+- `--api-token` requires `--require-auth`; without it the creation endpoints are open and the flag is rejected at startup.
+- Treat token secrets like passwords: pass them via the `API_TOKEN` environment variable or a config file rather than command-line flags where possible, and rotate them by restarting with a new value.
 
 ---
 

--- a/docs/server-options.md
+++ b/docs/server-options.md
@@ -120,6 +120,7 @@ See [Read-Only Mode](./read-only-mode) for split-instance deployments.
 | `--oidc-client-secret` | `OIDC_CLIENT_SECRET` | — | OAuth 2.0 client secret |
 | `--oidc-redirect-url` | `OIDC_REDIRECT_URL` | — | Callback URL registered with your OIDC provider (e.g. `https://yopass.example.com/auth/callback`) |
 | `--require-auth` | `REQUIRE_AUTH` | `false` | Require users to be authenticated before they can create secrets |
+| `--api-token` | `API_TOKEN` | — | Static bearer token(s) letting machine clients create secrets when `--require-auth` is set, formatted as `name:secret` (comma-separated for multiple) |
 | `--oidc-allowed-domains` | `OIDC_ALLOWED_DOMAINS` | — | Comma-separated email domains allowed to log in (e.g. `corp.example.com,example.com`) |
 | `--oidc-session-key` | `OIDC_SESSION_KEY` | — | 64-byte hex-encoded session key for sharing sessions across multiple instances. Generate with `openssl rand -hex 64` |
 | `--frontend-url` | `FRONTEND_URL` | — | Frontend base URL for post-login redirect in split-origin (OIDC + separate frontend) deployments |

--- a/pkg/server/apitoken.go
+++ b/pkg/server/apitoken.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// APIToken is a named static bearer token that lets machine clients
+// (internal services, automation) create secrets when --require-auth is
+// enabled, without going through the interactive OIDC browser flow.
+// Requests authenticate with "Authorization: Bearer <secret>" and are
+// attributed in audit logs as "service:<name>".
+type APIToken struct {
+	Name   string
+	Secret string
+}
+
+// minAPITokenLength is the minimum accepted secret length; shorter tokens
+// are too easy to brute-force for a credential that never expires.
+const minAPITokenLength = 16
+
+// ParseAPITokens parses --api-token values of the form "name:secret".
+// Error messages never include the secret so misconfigured values cannot
+// leak into logs.
+func ParseAPITokens(entries []string) ([]APIToken, error) {
+	seen := make(map[string]bool, len(entries))
+	tokens := make([]APIToken, 0, len(entries))
+	for _, entry := range entries {
+		name, secret, ok := strings.Cut(entry, ":")
+		if !ok || name == "" || secret == "" {
+			return nil, fmt.Errorf("invalid api-token entry: expected format name:secret")
+		}
+		if len(secret) < minAPITokenLength {
+			return nil, fmt.Errorf("api-token %q: secret must be at least %d characters", name, minAPITokenLength)
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate api-token name %q", name)
+		}
+		seen[name] = true
+		tokens = append(tokens, APIToken{Name: name, Secret: secret})
+	}
+	return tokens, nil
+}
+
+// bearerToken extracts the credential from an "Authorization: Bearer ..."
+// header, or returns "" when no bearer credential is present.
+func bearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(auth) > len(prefix) && strings.EqualFold(auth[:len(prefix)], prefix) {
+		return strings.TrimSpace(auth[len(prefix):])
+	}
+	return ""
+}
+
+// apiTokenSession returns a synthetic session for a request carrying a
+// valid API bearer token, or nil when no configured token matches.
+// Comparison is constant-time over SHA-256 digests so neither the token
+// length nor a partial match is observable through timing.
+func (y *Server) apiTokenSession(r *http.Request) *sessionData {
+	if len(y.APITokens) == 0 {
+		return nil
+	}
+	presented := bearerToken(r)
+	if presented == "" {
+		return nil
+	}
+	presentedSum := sha256.Sum256([]byte(presented))
+	for _, t := range y.APITokens {
+		expectedSum := sha256.Sum256([]byte(t.Secret))
+		if hmac.Equal(presentedSum[:], expectedSum[:]) {
+			return &sessionData{
+				Sub:   "api-token:" + t.Name,
+				Email: "service:" + t.Name,
+				Name:  t.Name,
+			}
+		}
+	}
+	return nil
+}
+
+// sessionContextKey carries an already-authenticated session on the request
+// context, set by requireAuthMiddleware for API token requests.
+type sessionContextKey struct{}
+
+// withSession returns a copy of ctx carrying s as the authenticated session.
+func withSession(ctx context.Context, s *sessionData) context.Context {
+	return context.WithValue(ctx, sessionContextKey{}, s)
+}
+
+// sessionFromContext returns the session stored by withSession, or nil.
+func sessionFromContext(ctx context.Context) *sessionData {
+	s, _ := ctx.Value(sessionContextKey{}).(*sessionData)
+	return s
+}

--- a/pkg/server/apitoken.go
+++ b/pkg/server/apitoken.go
@@ -13,10 +13,11 @@ import (
 // (internal services, automation) create secrets when --require-auth is
 // enabled, without going through the interactive OIDC browser flow.
 // Requests authenticate with "Authorization: Bearer <secret>" and are
-// attributed in audit logs as "service:<name>".
+// attributed in audit logs as "service:<name>". Only a SHA-256 digest of
+// the secret is retained after parsing.
 type APIToken struct {
 	Name   string
-	Secret string
+	digest [32]byte // SHA-256 of the configured secret
 }
 
 // minAPITokenLength is the minimum accepted secret length; shorter tokens
@@ -41,7 +42,7 @@ func ParseAPITokens(entries []string) ([]APIToken, error) {
 			return nil, fmt.Errorf("duplicate api-token name %q", name)
 		}
 		seen[name] = true
-		tokens = append(tokens, APIToken{Name: name, Secret: secret})
+		tokens = append(tokens, APIToken{Name: name, digest: sha256.Sum256([]byte(secret))})
 	}
 	return tokens, nil
 }
@@ -59,8 +60,9 @@ func bearerToken(r *http.Request) string {
 
 // apiTokenSession returns a synthetic session for a request carrying a
 // valid API bearer token, or nil when no configured token matches.
-// Comparison is constant-time over SHA-256 digests so neither the token
-// length nor a partial match is observable through timing.
+// The presented credential is hashed once and compared against digests
+// precomputed at parse time using constant-time equality, so a partial
+// match against a configured secret is not observable through timing.
 func (y *Server) apiTokenSession(r *http.Request) *sessionData {
 	if len(y.APITokens) == 0 {
 		return nil
@@ -71,8 +73,7 @@ func (y *Server) apiTokenSession(r *http.Request) *sessionData {
 	}
 	presentedSum := sha256.Sum256([]byte(presented))
 	for _, t := range y.APITokens {
-		expectedSum := sha256.Sum256([]byte(t.Secret))
-		if hmac.Equal(presentedSum[:], expectedSum[:]) {
+		if hmac.Equal(presentedSum[:], t.digest[:]) {
 			return &sessionData{
 				Sub:   "api-token:" + t.Name,
 				Email: "service:" + t.Name,

--- a/pkg/server/apitoken_test.go
+++ b/pkg/server/apitoken_test.go
@@ -1,0 +1,309 @@
+package server
+
+// Tests for machine-to-machine API token authentication on the
+// --require-auth gated creation endpoints.
+//
+// Uses mockOIDCProvider from oidc_test.go and the stream/request test
+// helpers (same package).
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jhaals/yopass/pkg/yopass"
+)
+
+const testAPITokenSecret = "0123456789abcdef0123456789abcdef"
+
+// enableAPITokens turns srv into a require-auth server with one API token
+// named "cmdb" configured.
+func enableAPITokens(srv *Server) {
+	srv.RequireAuth = true
+	srv.APITokens = []APIToken{{Name: "cmdb", Secret: testAPITokenSecret}}
+}
+
+func createSecretRequestWithAuth(authorization string) *http.Request {
+	body := `{"message":"` + pgpTestMessage + `","expiration":3600,"one_time":false}`
+	req := httptest.NewRequest(http.MethodPost, "/create/secret", strings.NewReader(body))
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+	return req
+}
+
+func TestParseAPITokens(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []string
+		want    []APIToken
+		wantErr string
+	}{
+		{
+			name:    "single valid token",
+			entries: []string{"cmdb:" + testAPITokenSecret},
+			want:    []APIToken{{Name: "cmdb", Secret: testAPITokenSecret}},
+		},
+		{
+			name:    "multiple tokens",
+			entries: []string{"cmdb:" + testAPITokenSecret, "ops:" + testAPITokenSecret + "x"},
+			want: []APIToken{
+				{Name: "cmdb", Secret: testAPITokenSecret},
+				{Name: "ops", Secret: testAPITokenSecret + "x"},
+			},
+		},
+		{
+			name:    "secret may contain colons",
+			entries: []string{"svc:abc:def:0123456789abcdef"},
+			want:    []APIToken{{Name: "svc", Secret: "abc:def:0123456789abcdef"}},
+		},
+		{
+			name:    "missing separator",
+			entries: []string{"justonevalue0123456789"},
+			wantErr: "expected format name:secret",
+		},
+		{
+			name:    "empty name",
+			entries: []string{":" + testAPITokenSecret},
+			wantErr: "expected format name:secret",
+		},
+		{
+			name:    "empty secret",
+			entries: []string{"cmdb:"},
+			wantErr: "expected format name:secret",
+		},
+		{
+			name:    "secret too short",
+			entries: []string{"cmdb:short"},
+			wantErr: "at least 16 characters",
+		},
+		{
+			name:    "duplicate name",
+			entries: []string{"cmdb:" + testAPITokenSecret, "cmdb:" + testAPITokenSecret + "x"},
+			wantErr: "duplicate api-token name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseAPITokens(tc.entries)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+				}
+				// The secret must never leak into the error message.
+				for _, entry := range tc.entries {
+					if _, secret, ok := strings.Cut(entry, ":"); ok && secret != "" && strings.Contains(err.Error(), secret) {
+						t.Fatalf("error message leaks token secret: %v", err)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %d tokens, got %d", len(tc.want), len(got))
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("token %d: expected %+v, got %+v", i, tc.want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
+func TestAPIToken_CreateSecret(t *testing.T) {
+	tests := []struct {
+		name          string
+		authorization string
+		allowedDomain string
+		expectedCode  int
+	}{
+		{
+			name:          "valid token → 200",
+			authorization: "Bearer " + testAPITokenSecret,
+			expectedCode:  http.StatusOK,
+		},
+		{
+			name:          "lowercase scheme accepted → 200",
+			authorization: "bearer " + testAPITokenSecret,
+			expectedCode:  http.StatusOK,
+		},
+		{
+			name:          "wrong token → 401",
+			authorization: "Bearer wrong-token-0123456789abcdef",
+			expectedCode:  http.StatusUnauthorized,
+		},
+		{
+			name:          "no credentials → 401",
+			authorization: "",
+			expectedCode:  http.StatusUnauthorized,
+		},
+		{
+			name:          "non-bearer scheme → 401",
+			authorization: "Basic " + testAPITokenSecret,
+			expectedCode:  http.StatusUnauthorized,
+		},
+		{
+			name:          "token bypasses email domain restriction → 200",
+			authorization: "Bearer " + testAPITokenSecret,
+			allowedDomain: "allowed.com",
+			expectedCode:  http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newServerWithOIDC(t, newTestDB())
+			enableAPITokens(&srv)
+			srv.AllowedEmailDomains = allowedDomainsOrNil(tc.allowedDomain)
+			handler := srv.HTTPHandler()
+
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, createSecretRequestWithAuth(tc.authorization))
+
+			if w.Code != tc.expectedCode {
+				t.Fatalf("expected %d, got %d: %s", tc.expectedCode, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestAPIToken_BearerIgnoredWhenNoTokensConfigured(t *testing.T) {
+	srv := newServerWithOIDC(t, newTestDB())
+	srv.RequireAuth = true // no APITokens configured
+	handler := srv.HTTPHandler()
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, createSecretRequestWithAuth("Bearer "+testAPITokenSecret))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIToken_SessionCookieStillWorks(t *testing.T) {
+	// Configuring API tokens must not break the interactive cookie flow.
+	srv := newServerWithOIDC(t, newTestDB())
+	enableAPITokens(&srv)
+	handler := srv.HTTPHandler()
+
+	req := createSecretRequestWithAuth("")
+	for _, c := range sessionCookiesFor(t, &srv) {
+		req.AddCookie(c)
+	}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIToken_AuditAttribution(t *testing.T) {
+	srv := newServerWithOIDC(t, newTestDB())
+	enableAPITokens(&srv)
+	audit := &capturingAuditLogger{}
+	srv.Audit = audit
+	handler := srv.HTTPHandler()
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, createSecretRequestWithAuth("Bearer "+testAPITokenSecret))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(audit.events) != 1 {
+		t.Fatalf("expected 1 audit event, got %d", len(audit.events))
+	}
+	e := audit.events[0]
+	if e.Event != "secret.created" || e.Outcome != OutcomeSuccess {
+		t.Errorf("unexpected event %q outcome %q", e.Event, e.Outcome)
+	}
+	if e.UserEmail != "service:cmdb" {
+		t.Errorf("expected user_email service:cmdb, got %q", e.UserEmail)
+	}
+	if e.UserSubject != "api-token:cmdb" {
+		t.Errorf("expected user_subject api-token:cmdb, got %q", e.UserSubject)
+	}
+}
+
+func TestAPIToken_FileUpload(t *testing.T) {
+	srv := newServerWithOIDC(t, newTestDB())
+	enableAPITokens(&srv)
+	handler := srv.HTTPHandler()
+
+	// Without credentials the upload is rejected.
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, streamUploadRequest(pgpBody("data"), "3600", "false", "test.bin"))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// With a valid token it succeeds.
+	req := streamUploadRequest(pgpBody("data"), "3600", "false", "test.bin")
+	req.Header.Set("Authorization", "Bearer "+testAPITokenSecret)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIToken_SecretRequestCreation(t *testing.T) {
+	srv := newServerWithOIDC(t, newTestDB())
+	enableAPITokens(&srv)
+	srv.License = LicenseStatus{Valid: true}
+	handler := srv.HTTPHandler()
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"public_key": testPublicKey(t),
+		"expiration": 3600,
+	})
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/request", bytes.NewReader(body)))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/request", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testAPITokenSecret)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIToken_DoesNotAuthorizeRetrieval(t *testing.T) {
+	// API tokens gate creation only; retrieving a RequireAuth-protected
+	// secret still demands an interactive session.
+	db := newTestDB()
+	srv := newServerWithOIDC(t, db)
+	enableAPITokens(&srv)
+	handler := srv.HTTPHandler()
+
+	const key = "0f5c8ac2-53a4-45a4-a3a8-b6f892bd52c2"
+	if err := db.Put(key, yopass.Secret{
+		Message:     pgpTestMessage,
+		Expiration:  3600,
+		RequireAuth: true,
+	}); err != nil {
+		t.Fatalf("DB.Put: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/secret/"+key, nil)
+	req.Header.Set("Authorization", "Bearer "+testAPITokenSecret)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/pkg/server/apitoken_test.go
+++ b/pkg/server/apitoken_test.go
@@ -8,6 +8,7 @@ package server
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -19,11 +20,17 @@ import (
 
 const testAPITokenSecret = "0123456789abcdef0123456789abcdef"
 
+// testAPIToken builds an APIToken as ParseAPITokens would, with the
+// secret's digest precomputed.
+func testAPIToken(name, secret string) APIToken {
+	return APIToken{Name: name, digest: sha256.Sum256([]byte(secret))}
+}
+
 // enableAPITokens turns srv into a require-auth server with one API token
 // named "cmdb" configured.
 func enableAPITokens(srv *Server) {
 	srv.RequireAuth = true
-	srv.APITokens = []APIToken{{Name: "cmdb", Secret: testAPITokenSecret}}
+	srv.APITokens = []APIToken{testAPIToken("cmdb", testAPITokenSecret)}
 }
 
 func createSecretRequestWithAuth(authorization string) *http.Request {
@@ -45,20 +52,20 @@ func TestParseAPITokens(t *testing.T) {
 		{
 			name:    "single valid token",
 			entries: []string{"cmdb:" + testAPITokenSecret},
-			want:    []APIToken{{Name: "cmdb", Secret: testAPITokenSecret}},
+			want:    []APIToken{testAPIToken("cmdb", testAPITokenSecret)},
 		},
 		{
 			name:    "multiple tokens",
 			entries: []string{"cmdb:" + testAPITokenSecret, "ops:" + testAPITokenSecret + "x"},
 			want: []APIToken{
-				{Name: "cmdb", Secret: testAPITokenSecret},
-				{Name: "ops", Secret: testAPITokenSecret + "x"},
+				testAPIToken("cmdb", testAPITokenSecret),
+				testAPIToken("ops", testAPITokenSecret+"x"),
 			},
 		},
 		{
 			name:    "secret may contain colons",
 			entries: []string{"svc:abc:def:0123456789abcdef"},
-			want:    []APIToken{{Name: "svc", Secret: "abc:def:0123456789abcdef"}},
+			want:    []APIToken{testAPIToken("svc", "abc:def:0123456789abcdef")},
 		},
 		{
 			name:    "missing separator",

--- a/pkg/server/oidc.go
+++ b/pkg/server/oidc.go
@@ -196,7 +196,13 @@ func (y *Server) isCrossOrigin(r *http.Request) bool {
 
 // getSession reads and decodes the session cookie.
 // Returns nil, nil when no session cookie is present (unauthenticated).
+// A session placed on the request context (an API token identity resolved
+// by requireAuthMiddleware) takes precedence over the cookie so handlers
+// attribute audit events to the service account.
 func (y *Server) getSession(r *http.Request) (*sessionData, error) {
+	if s := sessionFromContext(r.Context()); s != nil {
+		return s, nil
+	}
 	if y.CookieCodec == nil {
 		return nil, nil
 	}
@@ -372,8 +378,15 @@ func (y *Server) oidcMeHandler(w http.ResponseWriter, r *http.Request) {
 
 // requireAuthMiddleware returns 401 if there is no valid session, or 403 if
 // the authenticated user's email domain does not match --oidc-allowed-domains.
+// Machine clients may authenticate with a configured API bearer token instead
+// of an interactive OIDC session; token identities are service accounts, so
+// the email-domain restriction does not apply to them.
 func (y *Server) requireAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s := y.apiTokenSession(r); s != nil {
+			next.ServeHTTP(w, r.WithContext(withSession(r.Context(), s)))
+			return
+		}
 		s, err := y.getSession(r)
 		if err != nil || s == nil {
 			jsonError(w, http.StatusUnauthorized, "authentication required")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -54,8 +54,9 @@ type Server struct {
 	DisableReadReceipts   bool
 
 	// Authentication
-	RequireAuth         bool     // require authentication to create secrets
-	AllowedEmailDomains []string // restrict logins to these email domains
+	RequireAuth         bool       // require authentication to create secrets
+	AllowedEmailDomains []string   // restrict logins to these email domains
+	APITokens           []APIToken // static bearer tokens for machine-to-machine creation
 
 	// URLs and CORS
 	CORSAllowOrigin  string


### PR DESCRIPTION
Add --api-token (API_TOKEN) accepting name:secret pairs so backend services can create secrets via Authorization: Bearer when --require-auth is enabled, without the interactive OIDC flow.

- Tokens are matched in constant time and resolved by the require-auth middleware before the session cookie; identities are attributed in audit logs as service:<name>
- Tokens gate creation only (/create/secret, /create/file, /request); retrieval of auth-protected secrets still requires a session
- Service identities bypass --oidc-allowed-domains (no email domain)
- Startup validation: format, 16-char minimum secret, unique names, and rejection when --require-auth is not set

Closes #3654