### PR TITLE
Enforce atomic secret request lifecycle transitions across instances

### DIFF
--- a/cmd/yopass-server/main_test.go
+++ b/cmd/yopass-server/main_test.go
@@ -51,6 +51,10 @@ func (m *mockDatabase) Status(key string) (yopass.Secret, error) {
 	return yopass.Secret{}, errors.New("not implemented")
 }
 
+func (m *mockDatabase) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	return errors.New("not implemented")
+}
+
 func (m *mockDatabase) Health() error {
 	return m.healthErr
 }

--- a/cmd/yopass/main_test.go
+++ b/cmd/yopass/main_test.go
@@ -351,6 +351,19 @@ func (db *testDB) Status(key string) (yopass.Secret, error) {
 	return secret, nil
 }
 
+func (db *testDB) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	s, ok := db.data[key]
+	if !ok {
+		return server.ErrKeyNotFound
+	}
+	updated, err := fn(s)
+	if err != nil {
+		return err
+	}
+	db.data[key] = updated
+	return nil
+}
+
 func (db *testDB) Health() error {
 	return nil
 }

--- a/docs/secret-requests.md
+++ b/docs/secret-requests.md
@@ -55,6 +55,7 @@ The **Requests** entry in the navigation bar shows a counter badge with the numb
 - **Link integrity verification.** The link fragment carries the public key fingerprint. Since URL fragments are never sent to the server, a server that swapped the public key (to read secrets in transit) is detected by the responder's browser, which refuses to submit.
 - **One-time retrieval.** Retrieving the provided secret deletes it from the server before the response is sent.
 - **Management token.** Retrieval, revocation, and key rotation require a token returned once at creation time and stored alongside the private key. A bare request ID grants no control over the request.
+- **Atomic lifecycle transitions.** State changes (fulfill, key rotation) are applied with compare-and-swap operations in the storage backend, so concurrent attempts cannot overwrite each other's secret or resurrect a revoked request — including when multiple yopass instances share one Redis or Memcached backend.
 - **Audit trail.** With [audit logging](audit-logging) enabled, every interaction is recorded — `request.created`, `request.viewed` (a responder opening the link), `request.fulfilled`, `request.secret_accessed`, `request.revoked`, and `request.key_rotated` — including denied and failed attempts, without ever logging secret content. A purge from the UI is recorded as one `request.revoked` event per active request.
 
 ---

--- a/pkg/server/database.go
+++ b/pkg/server/database.go
@@ -1,6 +1,14 @@
 package server
 
-import "github.com/jhaals/yopass/pkg/yopass"
+import (
+	"errors"
+
+	"github.com/jhaals/yopass/pkg/yopass"
+)
+
+// ErrKeyNotFound is returned by Update when the key does not exist or is
+// deleted before the write commits.
+var ErrKeyNotFound = errors.New("key not found")
 
 // Database interface
 type Database interface {
@@ -8,5 +16,11 @@ type Database interface {
 	Put(key string, secret yopass.Secret) error
 	Delete(key string) (bool, error)
 	Status(key string) (yopass.Secret, error)
+	// Update atomically applies fn to the current value at key and stores the
+	// result with the returned secret's expiration. The read-modify-write is
+	// atomic across processes sharing the backend; implementations retry
+	// internally on contention. If fn returns an error the update is aborted
+	// and that error is returned unchanged.
+	Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error
 	Health() error
 }

--- a/pkg/server/filestore_db_test.go
+++ b/pkg/server/filestore_db_test.go
@@ -58,6 +58,21 @@ func (db *testDB) Status(key string) (yopass.Secret, error) {
 	}
 	return s, nil
 }
+func (db *testDB) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	s, ok := db.store[key]
+	if !ok {
+		return ErrKeyNotFound
+	}
+	updated, err := fn(s)
+	if err != nil {
+		return err
+	}
+	db.store[key] = updated
+	return nil
+}
+
 func (db *testDB) Health() error { return nil }
 
 func TestDatabaseFileStore_SaveLoadDelete(t *testing.T) {

--- a/pkg/server/memcached.go
+++ b/pkg/server/memcached.go
@@ -68,6 +68,48 @@ func (m *Memcached) Put(key string, secret yopass.Secret) error {
 		Expiration: secret.Expiration})
 }
 
+// Update atomically applies fn to the value at key using memcached CAS
+// tokens, retrying on contention.
+func (m *Memcached) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	var lastErr error
+	for i := 0; i < updateRetries; i++ {
+		item, err := m.Client.Get(key)
+		if err == memcache.ErrCacheMiss {
+			return ErrKeyNotFound
+		}
+		if err != nil {
+			return err
+		}
+		var s yopass.Secret
+		if err := json.Unmarshal(item.Value, &s); err != nil {
+			return err
+		}
+		updated, err := fn(s)
+		if err != nil {
+			return err
+		}
+		data, err := updated.ToJSON()
+		if err != nil {
+			return err
+		}
+		item.Value = data
+		item.Expiration = updated.Expiration
+		switch err := m.Client.CompareAndSwap(item); err {
+		case nil:
+			return nil
+		case memcache.ErrCacheMiss, memcache.ErrNotStored:
+			// Deleted or evicted since the read.
+			return ErrKeyNotFound
+		case memcache.ErrCASConflict:
+			// Modified since the read: reload and retry.
+			lastErr = err
+		default:
+			return err
+		}
+	}
+	return lastErr
+}
+
 // Delete key from memcached
 func (m *Memcached) Delete(key string) (bool, error) {
 	if err := m.Client.Delete(key); err != nil {

--- a/pkg/server/memcached_test.go
+++ b/pkg/server/memcached_test.go
@@ -239,7 +239,7 @@ func TestMemcachedUpdate(t *testing.T) {
 
 	m := NewMemcached(memcachedURL)
 
-	key := "update-test-memcached"
+	key := "update-test-" + t.Name()
 	defer func() { _, _ = m.Delete(key) }()
 
 	// Update of a missing key reports ErrKeyNotFound

--- a/pkg/server/memcached_test.go
+++ b/pkg/server/memcached_test.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"errors"
 	"os"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/bradfitz/gomemcache/memcache"
@@ -226,4 +229,73 @@ func TestMemcachedHealth(t *testing.T) {
 			t.Fatal("expected Health() to fail with invalid Memcached connection")
 		}
 	})
+}
+
+func TestMemcachedUpdate(t *testing.T) {
+	memcachedURL := os.Getenv("MEMCACHED")
+	if memcachedURL == "" {
+		t.Skip("Specify MEMCACHED env variable to test memcached database")
+	}
+
+	m := NewMemcached(memcachedURL)
+
+	key := "update-test-memcached"
+	defer func() { _, _ = m.Delete(key) }()
+
+	// Update of a missing key reports ErrKeyNotFound
+	if err := m.Update(key, func(s yopass.Secret) (yopass.Secret, error) {
+		return s, nil
+	}); err != ErrKeyNotFound {
+		t.Fatalf("expected ErrKeyNotFound, got %v", err)
+	}
+
+	if err := m.Put(key, yopass.Secret{Message: "0", Expiration: 3600}); err != nil {
+		t.Fatalf("error in Put(): %v", err)
+	}
+
+	// An error returned by fn aborts the update without writing
+	abort := errors.New("abort")
+	if err := m.Update(key, func(s yopass.Secret) (yopass.Secret, error) {
+		s.Message = "must not be stored"
+		return s, abort
+	}); err != abort {
+		t.Fatalf("expected abort error, got %v", err)
+	}
+	if s, err := m.Status(key); err != nil || s.Message != "0" {
+		t.Fatalf("aborted update must not write: %v %v", s, err)
+	}
+
+	// Concurrent increments must all land exactly once
+	const writers = 10
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				err := m.Update(key, func(s yopass.Secret) (yopass.Secret, error) {
+					n, err := strconv.Atoi(s.Message)
+					if err != nil {
+						return s, err
+					}
+					s.Message = strconv.Itoa(n + 1)
+					return s, nil
+				})
+				if err == nil {
+					return
+				}
+				// Retries are bounded per Update call; loop until this
+				// writer's increment lands.
+			}
+		}()
+	}
+	wg.Wait()
+
+	s, err := m.Status(key)
+	if err != nil {
+		t.Fatalf("error in Status(): %v", err)
+	}
+	if s.Message != strconv.Itoa(writers) {
+		t.Fatalf("lost updates: expected %d, got %s", writers, s.Message)
+	}
 }

--- a/pkg/server/redis.go
+++ b/pkg/server/redis.go
@@ -74,6 +74,50 @@ func (r *Redis) Put(key string, secret yopass.Secret) error {
 	).Err()
 }
 
+// updateRetries bounds the number of attempts an Update makes when it loses a
+// compare-and-swap race before giving up.
+const updateRetries = 5
+
+// Update atomically applies fn to the value at key using an optimistic
+// WATCH/MULTI/EXEC transaction, retrying on contention.
+func (r *Redis) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	ctx := context.Background()
+	var lastErr error
+	for i := 0; i < updateRetries; i++ {
+		err := r.client.Watch(ctx, func(tx *redis.Tx) error {
+			v, err := tx.Get(ctx, key).Result()
+			if err == redis.Nil {
+				return ErrKeyNotFound
+			}
+			if err != nil {
+				return err
+			}
+			var s yopass.Secret
+			if err := json.Unmarshal([]byte(v), &s); err != nil {
+				return err
+			}
+			updated, err := fn(s)
+			if err != nil {
+				return err
+			}
+			data, err := updated.ToJSON()
+			if err != nil {
+				return err
+			}
+			_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, key, data, time.Duration(updated.Expiration)*time.Second)
+				return nil
+			})
+			return err
+		}, key)
+		if err != redis.TxFailedErr {
+			return err
+		}
+		lastErr = err
+	}
+	return lastErr
+}
+
 // Delete key from Redis
 func (r *Redis) Delete(key string) (bool, error) {
 	res, err := r.client.Del(context.Background(), key).Result()

--- a/pkg/server/redis_test.go
+++ b/pkg/server/redis_test.go
@@ -2,7 +2,10 @@ package server
 
 import (
 	"context"
+	"errors"
 	"os"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/jhaals/yopass/pkg/yopass"
@@ -243,4 +246,76 @@ func TestRedisHealth(t *testing.T) {
 			t.Fatal("expected Health() to fail with invalid Redis connection")
 		}
 	})
+}
+
+func TestRedisUpdate(t *testing.T) {
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		t.Skip("Specify REDIS_URL env variable to test Redis database")
+	}
+
+	r, err := NewRedis(redisURL)
+	if err != nil {
+		t.Fatalf("error in NewRedis(): %v", err)
+	}
+
+	key := "update-test-" + t.Name()
+	defer func() { _, _ = r.Delete(key) }()
+
+	// Update of a missing key reports ErrKeyNotFound
+	if err := r.Update(key, func(s yopass.Secret) (yopass.Secret, error) {
+		return s, nil
+	}); err != ErrKeyNotFound {
+		t.Fatalf("expected ErrKeyNotFound, got %v", err)
+	}
+
+	if err := r.Put(key, yopass.Secret{Message: "0", Expiration: 3600}); err != nil {
+		t.Fatalf("error in Put(): %v", err)
+	}
+
+	// An error returned by fn aborts the update without writing
+	abort := errors.New("abort")
+	if err := r.Update(key, func(s yopass.Secret) (yopass.Secret, error) {
+		s.Message = "must not be stored"
+		return s, abort
+	}); err != abort {
+		t.Fatalf("expected abort error, got %v", err)
+	}
+	if s, err := r.Status(key); err != nil || s.Message != "0" {
+		t.Fatalf("aborted update must not write: %v %v", s, err)
+	}
+
+	// Concurrent increments must all land exactly once
+	const writers = 10
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				err := r.Update(key, func(s yopass.Secret) (yopass.Secret, error) {
+					n, err := strconv.Atoi(s.Message)
+					if err != nil {
+						return s, err
+					}
+					s.Message = strconv.Itoa(n + 1)
+					return s, nil
+				})
+				if err == nil {
+					return
+				}
+				// Retries are bounded per Update call; loop until this
+				// writer's increment lands.
+			}
+		}()
+	}
+	wg.Wait()
+
+	s, err := r.Status(key)
+	if err != nil {
+		t.Fatalf("error in Status(): %v", err)
+	}
+	if s.Message != strconv.Itoa(writers) {
+		t.Fatalf("lost updates: expected %d, got %s", writers, s.Message)
+	}
 }

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -90,6 +91,14 @@ func isPGPPublicKey(content string) bool {
 	return err == nil && len(ring) > 0
 }
 
+// Sentinel errors used by updateRequest mutation callbacks to signal why a
+// lifecycle transition was aborted.
+var (
+	errRequestNotFound  = errors.New("secret request not found")
+	errAlreadyFulfilled = errors.New("secret request already fulfilled")
+	errInvalidToken     = errors.New("invalid request token")
+)
+
 // loadRequest fetches and decodes a secret request from the database.
 func (y *Server) loadRequest(id string) (SecretRequest, bool) {
 	s, err := y.DB.Status(requestKeyPrefix + id)
@@ -115,6 +124,34 @@ func (y *Server) storeRequest(id string, r SecretRequest, ttl int32) error {
 	return y.DB.Put(requestKeyPrefix+id, yopass.Secret{
 		Message:    string(data),
 		Expiration: ttl,
+	})
+}
+
+// updateRequest atomically mutates a stored secret request via Database.Update
+// so lifecycle transitions are safe across multiple instances sharing one
+// backend. fn may return an error to abort the update; it is returned
+// unchanged. Records that fail validation (bad JSON, missing token hash,
+// expired) abort with errRequestNotFound.
+func (y *Server) updateRequest(id string, fn func(*SecretRequest) error) error {
+	return y.DB.Update(requestKeyPrefix+id, func(s yopass.Secret) (yopass.Secret, error) {
+		var r SecretRequest
+		if err := json.Unmarshal([]byte(s.Message), &r); err != nil || r.TokenHash == "" {
+			return s, errRequestNotFound
+		}
+		if r.remainingTTL() == 0 {
+			return s, errRequestNotFound
+		}
+		if err := fn(&r); err != nil {
+			return s, err
+		}
+		data, err := json.Marshal(r)
+		if err != nil {
+			return s, err
+		}
+		return yopass.Secret{
+			Message:    string(data),
+			Expiration: r.remainingTTL(),
+		}, nil
 	})
 }
 
@@ -254,25 +291,24 @@ func (y *Server) fulfillSecretRequest(w http.ResponseWriter, request *http.Reque
 		return
 	}
 
-	y.requestMu.Lock()
-	defer y.requestMu.Unlock()
-
-	req, ok := y.loadRequest(id)
-	if !ok {
+	err := y.updateRequest(id, func(req *SecretRequest) error {
+		if req.State == RequestStateFulfilled {
+			return errAlreadyFulfilled
+		}
+		req.State = RequestStateFulfilled
+		req.Secret = body.Message
+		return nil
+	})
+	switch {
+	case errors.Is(err, ErrKeyNotFound) || errors.Is(err, errRequestNotFound):
 		audit.failure("not found")
 		jsonError(w, http.StatusNotFound, "Secret request not found")
 		return
-	}
-
-	if req.State == RequestStateFulfilled {
+	case errors.Is(err, errAlreadyFulfilled):
 		audit.denied("already fulfilled")
 		jsonError(w, http.StatusConflict, "A secret has already been provided for this request")
 		return
-	}
-
-	req.State = RequestStateFulfilled
-	req.Secret = body.Message
-	if err := y.storeRequest(id, req, req.remainingTTL()); err != nil {
+	case err != nil:
 		y.Logger.Error("Unable to store fulfilled request", zap.Error(err))
 		audit.failure("database error")
 		jsonError(w, http.StatusInternalServerError, "Failed to store secret in database")
@@ -295,9 +331,6 @@ func (y *Server) fetchRequestSecret(w http.ResponseWriter, request *http.Request
 	audit := y.newAuditor("request.secret_accessed", y.getRealClientIP(request), nil)
 	audit.setSecretID(id)
 
-	y.requestMu.Lock()
-	defer y.requestMu.Unlock()
-
 	req, ok := y.loadRequest(id)
 	if !ok {
 		audit.failure("not found")
@@ -319,6 +352,9 @@ func (y *Server) fetchRequestSecret(w http.ResponseWriter, request *http.Request
 
 	// The secret can only be retrieved once: delete before responding so a
 	// failed delete never results in a secret that can be fetched twice.
+	// Delete reporting whether a key was removed makes this a single-winner
+	// claim; fulfilled records are immutable (fulfill and rotate refuse to
+	// touch them) so the secret read above cannot be stale.
 	deleted, err := y.DB.Delete(requestKeyPrefix + id)
 	if err != nil || !deleted {
 		y.Logger.Error("Failed to delete fulfilled request", zap.Error(err))
@@ -388,30 +424,31 @@ func (y *Server) rotateRequestKey(w http.ResponseWriter, request *http.Request) 
 		return
 	}
 
-	y.requestMu.Lock()
-	defer y.requestMu.Unlock()
-
-	req, ok := y.loadRequest(id)
-	if !ok {
+	token := request.Header.Get(requestTokenHeader)
+	err := y.updateRequest(id, func(req *SecretRequest) error {
+		if !req.tokenValid(token) {
+			return errInvalidToken
+		}
+		if req.State == RequestStateFulfilled {
+			return errAlreadyFulfilled
+		}
+		req.PublicKey = body.PublicKey
+		return nil
+	})
+	switch {
+	case errors.Is(err, ErrKeyNotFound) || errors.Is(err, errRequestNotFound):
 		audit.failure("not found")
 		jsonError(w, http.StatusNotFound, "Secret request not found")
 		return
-	}
-
-	if !req.tokenValid(request.Header.Get(requestTokenHeader)) {
+	case errors.Is(err, errInvalidToken):
 		audit.denied("invalid management token")
 		jsonError(w, http.StatusUnauthorized, "Invalid request token")
 		return
-	}
-
-	if req.State == RequestStateFulfilled {
+	case errors.Is(err, errAlreadyFulfilled):
 		audit.denied("already fulfilled")
 		jsonError(w, http.StatusConflict, "A secret has already been provided for this request")
 		return
-	}
-
-	req.PublicKey = body.PublicKey
-	if err := y.storeRequest(id, req, req.remainingTTL()); err != nil {
+	case err != nil:
 		y.Logger.Error("Unable to store rotated request", zap.Error(err))
 		audit.failure("database error")
 		jsonError(w, http.StatusInternalServerError, "Failed to update request")

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -138,7 +138,11 @@ func (y *Server) updateRequest(id string, fn func(*SecretRequest) error) error {
 		if err := json.Unmarshal([]byte(s.Message), &r); err != nil || r.TokenHash == "" {
 			return s, errRequestNotFound
 		}
-		if r.remainingTTL() == 0 {
+		// Compute the TTL once: a second call could return 0 after the
+		// validation, and a zero expiration means "never expire" to the
+		// backends, which would persist an expired request indefinitely.
+		ttl := r.remainingTTL()
+		if ttl == 0 {
 			return s, errRequestNotFound
 		}
 		if err := fn(&r); err != nil {
@@ -150,7 +154,7 @@ func (y *Server) updateRequest(id string, fn func(*SecretRequest) error) error {
 		}
 		return yopass.Secret{
 			Message:    string(data),
-			Expiration: r.remainingTTL(),
+			Expiration: ttl,
 		}, nil
 	})
 }
@@ -356,10 +360,17 @@ func (y *Server) fetchRequestSecret(w http.ResponseWriter, request *http.Request
 	// claim; fulfilled records are immutable (fulfill and rotate refuse to
 	// touch them) so the secret read above cannot be stale.
 	deleted, err := y.DB.Delete(requestKeyPrefix + id)
-	if err != nil || !deleted {
+	if err != nil {
 		y.Logger.Error("Failed to delete fulfilled request", zap.Error(err))
 		audit.failure("failed to claim secret")
 		jsonError(w, http.StatusInternalServerError, "Failed to process secret")
+		return
+	}
+	if !deleted {
+		// A concurrent fetch or revoke claimed the request between the load
+		// and the delete; it is gone, not broken.
+		audit.failure("already claimed")
+		jsonError(w, http.StatusNotFound, "Secret request not found")
 		return
 	}
 

--- a/pkg/server/request_test.go
+++ b/pkg/server/request_test.go
@@ -669,3 +669,38 @@ func TestSecretRequestFulfillAfterRevoke(t *testing.T) {
 		t.Fatal("revoked request was re-created by fulfill")
 	}
 }
+
+// claimRaceDB simulates the request disappearing between the fetch handler's
+// load and its delete-as-claim, as when a concurrent fetch or revoke on
+// another instance wins the claim.
+type claimRaceDB struct{ *memoryDB }
+
+func (db *claimRaceDB) Delete(key string) (bool, error) { return false, nil }
+
+func TestSecretRequestFetchAlreadyClaimed(t *testing.T) {
+	db := newMemoryDB()
+	y := newRequestTestServer(t, &claimRaceDB{db}, true)
+	handler := y.HTTPHandler()
+
+	id, token := createRequest(t, handler, testPublicKey(t), "", 3600)
+
+	encrypted, err := yopass.Encrypt(strings.NewReader("hunter2"), "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(map[string]string{"message": encrypted})
+	req, _ := http.NewRequest("POST", "/request/"+id+"/secret", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("fulfill: status %d", rr.Code)
+	}
+
+	req, _ = http.NewRequest("GET", "/request/"+id+"/secret", nil)
+	req.Header.Set(requestTokenHeader, token)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("fetch of a concurrently claimed request should be 404: status %d body %s", rr.Code, rr.Body.String())
+	}
+}

--- a/pkg/server/request_test.go
+++ b/pkg/server/request_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 // memoryDB is a stateful in-memory Database used to exercise the full secret
 // request lifecycle.
 type memoryDB struct {
+	mu   sync.Mutex
 	data map[string]yopass.Secret
 }
 
@@ -29,6 +31,8 @@ func newMemoryDB() *memoryDB {
 }
 
 func (db *memoryDB) Get(key string) (yopass.Secret, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	s, ok := db.data[key]
 	if !ok {
 		return yopass.Secret{}, fmt.Errorf("not found")
@@ -41,16 +45,35 @@ func (db *memoryDB) Status(key string) (yopass.Secret, error) {
 }
 
 func (db *memoryDB) Put(key string, secret yopass.Secret) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	db.data[key] = secret
 	return nil
 }
 
 func (db *memoryDB) Delete(key string) (bool, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	if _, ok := db.data[key]; !ok {
 		return false, nil
 	}
 	delete(db.data, key)
 	return true, nil
+}
+
+func (db *memoryDB) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	s, ok := db.data[key]
+	if !ok {
+		return ErrKeyNotFound
+	}
+	updated, err := fn(s)
+	if err != nil {
+		return err
+	}
+	db.data[key] = updated
+	return nil
 }
 
 func (db *memoryDB) Health() error { return nil }
@@ -528,5 +551,121 @@ func TestSecretRequestsConfigEnabled(t *testing.T) {
 	}
 	if config["SECRET_REQUESTS"] != true {
 		t.Fatalf("SECRET_REQUESTS should be true with license: %v", config["SECRET_REQUESTS"])
+	}
+}
+
+// TestSecretRequestConcurrentFulfill runs concurrent fulfillments through two
+// Server instances sharing one database, as in a multi-instance deployment.
+// Exactly one responder may win; the stored ciphertext must belong to the
+// winner (regression test for the cross-instance last-write-wins overwrite).
+func TestSecretRequestConcurrentFulfill(t *testing.T) {
+	db := newMemoryDB()
+	serverA := newRequestTestServer(t, db, true)
+	serverB := newRequestTestServer(t, db, true)
+	handlers := []http.Handler{serverA.HTTPHandler(), serverB.HTTPHandler()}
+
+	id, token := createRequest(t, handlers[0], testPublicKey(t), "", 3600)
+
+	const responders = 8
+	messages := make([]string, responders)
+	for i := range messages {
+		encrypted, err := yopass.Encrypt(strings.NewReader(fmt.Sprintf("secret-%d", i)), "key")
+		if err != nil {
+			t.Fatal(err)
+		}
+		messages[i] = encrypted
+	}
+
+	codes := make([]int, responders)
+	var wg sync.WaitGroup
+	var start sync.WaitGroup
+	start.Add(1)
+	for i := 0; i < responders; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			body, _ := json.Marshal(map[string]string{"message": messages[i]})
+			req, _ := http.NewRequest("POST", "/request/"+id+"/secret", bytes.NewReader(body))
+			rr := httptest.NewRecorder()
+			start.Wait()
+			handlers[i%len(handlers)].ServeHTTP(rr, req)
+			codes[i] = rr.Code
+		}(i)
+	}
+	start.Done()
+	wg.Wait()
+
+	winner := -1
+	for i, code := range codes {
+		switch code {
+		case http.StatusOK:
+			if winner != -1 {
+				t.Fatalf("both responder %d and %d got 200; codes: %v", winner, i, codes)
+			}
+			winner = i
+		case http.StatusConflict:
+		default:
+			t.Fatalf("responder %d: unexpected status %d; codes: %v", i, code, codes)
+		}
+	}
+	if winner == -1 {
+		t.Fatalf("no responder succeeded; codes: %v", codes)
+	}
+
+	req, _ := http.NewRequest("GET", "/request/"+id+"/secret", nil)
+	req.Header.Set(requestTokenHeader, token)
+	rr := httptest.NewRecorder()
+	handlers[1].ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("fetch: status %d body %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Message != messages[winner] {
+		t.Fatal("stored ciphertext does not match the winning responder's message")
+	}
+}
+
+// TestSecretRequestFulfillAfterRevoke verifies that fulfilling a revoked
+// request fails and never re-creates the record (regression test for the
+// revoke-vs-fulfill resurrection: fulfill must go through an atomic update
+// that fails on a missing key, not a blind put).
+func TestSecretRequestFulfillAfterRevoke(t *testing.T) {
+	db := newMemoryDB()
+	serverA := newRequestTestServer(t, db, true)
+	serverB := newRequestTestServer(t, db, true)
+	handlerA, handlerB := serverA.HTTPHandler(), serverB.HTTPHandler()
+
+	id, token := createRequest(t, handlerA, testPublicKey(t), "", 3600)
+
+	req, _ := http.NewRequest("DELETE", "/request/"+id, nil)
+	req.Header.Set(requestTokenHeader, token)
+	rr := httptest.NewRecorder()
+	handlerB.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("revoke: status %d", rr.Code)
+	}
+
+	encrypted, err := yopass.Encrypt(strings.NewReader("hunter2"), "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(map[string]string{"message": encrypted})
+	req, _ = http.NewRequest("POST", "/request/"+id+"/secret", bytes.NewReader(body))
+	rr = httptest.NewRecorder()
+	handlerA.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("fulfill after revoke should be 404: status %d body %s", rr.Code, rr.Body.String())
+	}
+
+	db.mu.Lock()
+	_, resurrected := db.data[requestKeyPrefix+id]
+	db.mu.Unlock()
+	if resurrected {
+		t.Fatal("revoked request was re-created by fulfill")
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
@@ -79,12 +78,6 @@ type Server struct {
 	// ForceExpiration, when non-empty, is the server-enforced secret lifetime
 	// ("1h", "1d" or "1w"). Clients may not choose a different value.
 	ForceExpiration string
-
-	// requestMu serializes load → check → store sequences on secret requests
-	// so two concurrent fulfillments cannot both pass the pending check and
-	// silently overwrite each other. Guards a single instance only; the
-	// database layer has no compare-and-swap.
-	requestMu sync.Mutex
 }
 
 // jsonError writes a {"message": ...} error body with the given status code

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -41,6 +41,9 @@ func (db *mockDB) Delete(key string) (bool, error)            { return true, nil
 func (db *mockDB) Status(key string) (yopass.Secret, error) {
 	return yopass.Secret{Message: `***ENCRYPTED***`}, nil
 }
+func (db *mockDB) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	return nil
+}
 func (db *mockDB) Health() error { return nil }
 
 type brokenDB struct{}
@@ -53,6 +56,9 @@ func (db *brokenDB) Delete(key string) (bool, error)            { return false, 
 func (db *brokenDB) Status(key string) (yopass.Secret, error) {
 	return yopass.Secret{}, fmt.Errorf("Some error")
 }
+func (db *brokenDB) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	return fmt.Errorf("Some error")
+}
 func (db *brokenDB) Health() error { return fmt.Errorf("Some error") }
 
 // brokenDeleteDB simulates a DB where Status succeeds but Delete returns an error.
@@ -62,7 +68,10 @@ func (db *brokenDeleteDB) Get(key string) (yopass.Secret, error)      { return y
 func (db *brokenDeleteDB) Put(key string, secret yopass.Secret) error { return nil }
 func (db *brokenDeleteDB) Delete(key string) (bool, error)            { return false, fmt.Errorf("Some error") }
 func (db *brokenDeleteDB) Status(key string) (yopass.Secret, error)   { return yopass.Secret{}, nil }
-func (db *brokenDeleteDB) Health() error                              { return nil }
+func (db *brokenDeleteDB) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	return nil
+}
+func (db *brokenDeleteDB) Health() error { return nil }
 
 // mockBrokenDB2 simulates a DB where Get succeeds but Delete reports not found.
 type mockBrokenDB2 struct{}
@@ -73,7 +82,10 @@ func (db *mockBrokenDB2) Get(key string) (yopass.Secret, error) {
 func (db *mockBrokenDB2) Put(key string, secret yopass.Secret) error { return fmt.Errorf("Some error") }
 func (db *mockBrokenDB2) Delete(key string) (bool, error)            { return false, nil }
 func (db *mockBrokenDB2) Status(key string) (yopass.Secret, error)   { return yopass.Secret{}, nil }
-func (db *mockBrokenDB2) Health() error                              { return nil }
+func (db *mockBrokenDB2) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	return fmt.Errorf("Some error")
+}
+func (db *mockBrokenDB2) Health() error { return nil }
 
 // mockStatusDB returns a configurable secret for status/get tests.
 type mockStatusDB struct {
@@ -94,6 +106,9 @@ func (db *mockStatusDB) Status(key string) (yopass.Secret, error) {
 		return yopass.Secret{}, fmt.Errorf("Secret not found")
 	}
 	return yopass.Secret{Message: "test", OneTime: db.oneTime}, nil
+}
+func (db *mockStatusDB) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	return nil
 }
 func (db *mockStatusDB) Health() error { return nil }
 
@@ -1446,6 +1461,9 @@ func (db *mockHealthDB) Delete(key string) (bool, error) {
 func (db *mockHealthDB) Status(key string) (yopass.Secret, error) {
 	return yopass.Secret{}, nil
 }
+func (db *mockHealthDB) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	return nil
+}
 func (db *mockHealthDB) Health() error {
 	if !db.healthy {
 		return fmt.Errorf("database unhealthy")
@@ -2024,7 +2042,7 @@ func TestLogoHandler(t *testing.T) {
 }
 
 func TestCreateSecret_ForceExpiration(t *testing.T) {
-validPGPMessage := `-----BEGIN PGP MESSAGE-----
+	validPGPMessage := `-----BEGIN PGP MESSAGE-----
 Version: OpenPGP.js v4.10.8
 Comment: https://openpgpjs.org
 
@@ -2033,93 +2051,93 @@ xtt90k4BqHuTCLNlFRJjuiuE8zdIc+j5zTN5zihxUReVqokeqULLOx2FBMHZ
 sbfqaG/iDbp+qDOc98IagMyPrEqKDxnhVVOraXy5dD9RDsntLso=
 =0vwU
 -----END PGP MESSAGE-----`
-escapedPGP := strings.ReplaceAll(validPGPMessage, "\n", "\\n")
+	escapedPGP := strings.ReplaceAll(validPGPMessage, "\n", "\\n")
 
-t.Run("reject when expiration does not match forced value", func(t *testing.T) {
-y := newTestServer(t, &mockDB{}, 10000, false)
-y.ForceExpiration = "1h"
-body := strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 86400}`, escapedPGP))
-req, _ := http.NewRequest("POST", "/secret", body)
-rr := httptest.NewRecorder()
-y.createSecret(rr, req)
+	t.Run("reject when expiration does not match forced value", func(t *testing.T) {
+		y := newTestServer(t, &mockDB{}, 10000, false)
+		y.ForceExpiration = "1h"
+		body := strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 86400}`, escapedPGP))
+		req, _ := http.NewRequest("POST", "/secret", body)
+		rr := httptest.NewRecorder()
+		y.createSecret(rr, req)
 
-if rr.Code != http.StatusBadRequest {
-t.Fatalf("expected 400, got %d", rr.Code)
-}
-var s yopass.Secret
-json.Unmarshal(rr.Body.Bytes(), &s)
-if !strings.Contains(s.Message, "server policy") {
-t.Fatalf("expected policy error, got %q", s.Message)
-}
-})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rr.Code)
+		}
+		var s yopass.Secret
+		json.Unmarshal(rr.Body.Bytes(), &s)
+		if !strings.Contains(s.Message, "server policy") {
+			t.Fatalf("expected policy error, got %q", s.Message)
+		}
+	})
 
-t.Run("accept when expiration matches forced value", func(t *testing.T) {
-y := newTestServer(t, &mockDB{}, 10000, false)
-y.ForceExpiration = "1h"
-body := strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 3600}`, escapedPGP))
-req, _ := http.NewRequest("POST", "/secret", body)
-rr := httptest.NewRecorder()
-y.createSecret(rr, req)
+	t.Run("accept when expiration matches forced value", func(t *testing.T) {
+		y := newTestServer(t, &mockDB{}, 10000, false)
+		y.ForceExpiration = "1h"
+		body := strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 3600}`, escapedPGP))
+		req, _ := http.NewRequest("POST", "/secret", body)
+		rr := httptest.NewRecorder()
+		y.createSecret(rr, req)
 
-if rr.Code != http.StatusOK {
-t.Fatalf("expected 200, got %d", rr.Code)
-}
-})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rr.Code)
+		}
+	})
 
-t.Run("no enforcement when force-expiration is empty", func(t *testing.T) {
-y := newTestServer(t, &mockDB{}, 10000, false)
-body := strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 86400}`, escapedPGP))
-req, _ := http.NewRequest("POST", "/secret", body)
-rr := httptest.NewRecorder()
-y.createSecret(rr, req)
+	t.Run("no enforcement when force-expiration is empty", func(t *testing.T) {
+		y := newTestServer(t, &mockDB{}, 10000, false)
+		body := strings.NewReader(fmt.Sprintf(`{"message": "%s", "expiration": 86400}`, escapedPGP))
+		req, _ := http.NewRequest("POST", "/secret", body)
+		rr := httptest.NewRecorder()
+		y.createSecret(rr, req)
 
-if rr.Code != http.StatusOK {
-t.Fatalf("expected 200, got %d", rr.Code)
-}
-})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rr.Code)
+		}
+	})
 }
 
 func TestConfigHandler_ForceExpiration(t *testing.T) {
-t.Run("includes FORCE_EXPIRATION when set", func(t *testing.T) {
-s := &Server{
-Registry:        prometheus.NewRegistry(),
-Logger:          zaptest.NewLogger(t),
-ForceExpiration: "1d",
-}
-req := httptest.NewRequest(http.MethodGet, "/config", nil)
-w := httptest.NewRecorder()
-s.configHandler(w, req)
+	t.Run("includes FORCE_EXPIRATION when set", func(t *testing.T) {
+		s := &Server{
+			Registry:        prometheus.NewRegistry(),
+			Logger:          zaptest.NewLogger(t),
+			ForceExpiration: "1d",
+		}
+		req := httptest.NewRequest(http.MethodGet, "/config", nil)
+		w := httptest.NewRecorder()
+		s.configHandler(w, req)
 
-var cfg map[string]interface{}
-if err := json.NewDecoder(w.Result().Body).Decode(&cfg); err != nil {
-t.Fatalf("decode: %v", err)
-}
+		var cfg map[string]interface{}
+		if err := json.NewDecoder(w.Result().Body).Decode(&cfg); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
 
-fe, ok := cfg["FORCE_EXPIRATION"]
-if !ok {
-t.Fatal("FORCE_EXPIRATION missing from config")
-}
-if fe.(float64) != 86400 {
-t.Fatalf("expected 86400, got %v", fe)
-}
-})
+		fe, ok := cfg["FORCE_EXPIRATION"]
+		if !ok {
+			t.Fatal("FORCE_EXPIRATION missing from config")
+		}
+		if fe.(float64) != 86400 {
+			t.Fatalf("expected 86400, got %v", fe)
+		}
+	})
 
-t.Run("omits FORCE_EXPIRATION when not set", func(t *testing.T) {
-s := &Server{
-Registry: prometheus.NewRegistry(),
-Logger:   zaptest.NewLogger(t),
-}
-req := httptest.NewRequest(http.MethodGet, "/config", nil)
-w := httptest.NewRecorder()
-s.configHandler(w, req)
+	t.Run("omits FORCE_EXPIRATION when not set", func(t *testing.T) {
+		s := &Server{
+			Registry: prometheus.NewRegistry(),
+			Logger:   zaptest.NewLogger(t),
+		}
+		req := httptest.NewRequest(http.MethodGet, "/config", nil)
+		w := httptest.NewRecorder()
+		s.configHandler(w, req)
 
-var cfg map[string]interface{}
-if err := json.NewDecoder(w.Result().Body).Decode(&cfg); err != nil {
-t.Fatalf("decode: %v", err)
-}
+		var cfg map[string]interface{}
+		if err := json.NewDecoder(w.Result().Body).Decode(&cfg); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
 
-if _, ok := cfg["FORCE_EXPIRATION"]; ok {
-t.Fatal("FORCE_EXPIRATION should not be in config when not set")
-}
-})
+		if _, ok := cfg["FORCE_EXPIRATION"]; ok {
+			t.Fatal("FORCE_EXPIRATION should not be in config when not set")
+		}
+	})
 }

--- a/pkg/yopass/client_test.go
+++ b/pkg/yopass/client_test.go
@@ -128,6 +128,18 @@ func (db *testDB) Status(key string) (yopass.Secret, error) {
 	return yopass.Secret{Message: msg}, nil
 }
 
+func (db *testDB) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	s, err := db.Get(key)
+	if err != nil {
+		return server.ErrKeyNotFound
+	}
+	updated, err := fn(s)
+	if err != nil {
+		return err
+	}
+	return db.Put(key, updated)
+}
+
 func (db *testDB) Health() error {
 	return nil
 }


### PR DESCRIPTION
The fulfill, rotate and fetch handlers serialized their load-check-store sequences with an in-process mutex, which does not protect deployments running multiple instances against a shared Redis or Memcached backend. Concurrent fulfillments on different instances could both pass the pending check and silently overwrite each other's ciphertext, and a fulfill racing a revoke could re-store the deleted record, leaving a revoked request retrievable until expiry.

Add an atomic Update operation to the Database interface, implemented with WATCH/MULTI/EXEC transactions in Redis and CAS tokens in Memcached, and run the fulfill and rotate state checks inside it. A concurrent fulfill now conflicts and returns 409, and fulfilling a revoked request fails with 404 instead of resurrecting it. The in-process mutex is removed; fetch keeps its delete-as-claim which is single-winner since fulfilled records are now immutable.