### PR TITLE
fix: complete RFC 9580 crypto modernization (Argon2 S2K + 256-bit keys)

### DIFF
--- a/pkg/yopass/yopass.go
+++ b/pkg/yopass/yopass.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp/s2k"
 )
 
 // ErrEmptyKey is returned when no encryption key is provided.
@@ -33,6 +34,7 @@ var pgpConfig = &packet.Config{
 	DefaultCipher:          packet.CipherAES256,
 	DefaultCompressionAlgo: packet.CompressionNone,
 	AEADConfig:             &packet.AEADConfig{DefaultMode: packet.AEADModeGCM},
+	S2KConfig:              &s2k.Config{S2KMode: s2k.Argon2S2K},
 }
 
 var pgpHeader = map[string]string{
@@ -194,13 +196,11 @@ func GenerateID() (string, error) {
 // GenerateKey creates a new encryption key from a cryptographically secure
 // random number generator. The format matches the Javascript implementation.
 func GenerateKey() (string, error) {
-	const length = 22
-
-	b := make([]byte, length)
+	b := make([]byte, 32) // 256 bits
 	if _, err := rand.Read(b); err != nil {
 		return "", err
 	}
-	return base64.URLEncoding.EncodeToString(b)[:length], nil
+	return base64.RawURLEncoding.EncodeToString(b), nil // 43 chars, no padding
 }
 
 // SecretURL returns a URL which decryts the specified secret in the browser.

--- a/pkg/yopass/yopass_test.go
+++ b/pkg/yopass/yopass_test.go
@@ -236,7 +236,7 @@ func TestGenerateID(t *testing.T) {
 }
 
 func TestGenerateKey(t *testing.T) {
-	format := regexp.MustCompile("^[a-zA-Z0-9-_]{22}$")
+	format := regexp.MustCompile("^[a-zA-Z0-9-_]{43}$")
 
 	tests := make(map[string]struct{})
 	for i := 0; i < 10_000; i++ {

--- a/website/src/shared/lib/crypto.ts
+++ b/website/src/shared/lib/crypto.ts
@@ -14,6 +14,7 @@ import {
 export const encryptionConfig: Partial<Config> = {
   aeadProtect: true,
   preferredAEADAlgorithm: enums.aead.gcm,
+  s2kType: enums.s2k.argon2,
 };
 
 export async function decryptMessage(


### PR DESCRIPTION
- Switch from iterated SHA-256 S2K to memory-hard Argon2 (RFC 9580)
- Increase key entropy from 131 bits (22 chars) to 256 bits (32 bytes)
- Update test regex to match new 43-char base64url format

Closes #3369