### PR TITLE
Add opt-in Argon2 key derivation via --argon2 flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ yopass-server --memcached localhost:11211
 yopass-server --database redis --redis redis://localhost:6379/0
 ```
 
+Password key derivation can optionally be hardened with memory-hard [Argon2id](https://datatracker.ietf.org/doc/rfc9106/) via the `--argon2` flag. It is opt-in because it requires the `'wasm-unsafe-eval'` CSP directive, which reverse proxies that override the `Content-Security-Policy` header must add manually — see [Argon2 key derivation](https://yopass.se/docs/server-options#argon2-key-derivation).
+
 For the full flag reference see [yopass.se/docs/server-options](https://yopass.se/docs/server-options). Topic-specific guides:
 
 | Guide | Description |

--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -88,6 +88,7 @@ func init() {
 	pflag.String("tls-cert", "", "path to TLS certificate")
 	pflag.String("tls-key", "", "path to TLS key")
 	pflag.Bool("force-onetime-secrets", false, "reject non onetime secrets from being created")
+	pflag.Bool("argon2", false, "use Argon2 for password key derivation (adds 'wasm-unsafe-eval' to the CSP script-src directive)")
 	pflag.String("cors-allow-origin", "*", "Access-Control-Allow-Origin")
 	pflag.Bool("disable-upload", false, "disable the /file upload endpoints")
 	pflag.Bool("read-only", false, "disable all secret creation endpoints (retrieval-only mode)")
@@ -390,6 +391,7 @@ func main() {
 		Audit:               auditLogger,
 		Webhooks:            webhooks,
 
+		Argon2:                viper.GetBool("argon2"),
 		ReadOnly:              viper.GetBool("read-only"),
 		DisableUpload:         viper.GetBool("disable-upload"),
 		PrefetchSecret:        viper.GetBool("prefetch-secret"),

--- a/cmd/yopass/main.go
+++ b/cmd/yopass/main.go
@@ -178,6 +178,8 @@ func encryptFileByName(filename string, out io.Writer) error {
 		return fmt.Errorf("Failed to get file info: %w", err)
 	}
 
+	configureArgon2()
+
 	data, err := yopass.EncryptBinary(in, key, stat.Name())
 	if err != nil {
 		return fmt.Errorf("Failed to encrypt file: %w", err)
@@ -215,6 +217,8 @@ func encrypt(in io.ReadCloser, out io.Writer) error {
 		return fmt.Errorf("Failed to generate encryption key: %w", err)
 	}
 
+	configureArgon2()
+
 	msg, err := yopass.Encrypt(in, key)
 	if err != nil {
 		return fmt.Errorf("Failed to encrypt secret: %w", err)
@@ -232,6 +236,18 @@ func encrypt(in io.ReadCloser, out io.Writer) error {
 	url := viper.GetString("url")
 	_, err = fmt.Fprintln(out, yopass.SecretURL(url, id, key, viper.IsSet("file"), viper.IsSet("key")))
 	return err
+}
+
+// configureArgon2 reads the server /config endpoint and enables Argon2 key
+// derivation when the server has it enabled (--argon2). Errors are ignored
+// on purpose: if the config cannot be fetched the CLI falls back to the
+// default key derivation, which every yopass server accepts. Decryption
+// needs no configuration since the S2K type is stored in the message.
+func configureArgon2() {
+	config, err := yopass.FetchServerConfig(viper.GetString("api"))
+	if err == nil && config.Argon2 {
+		yopass.EnableArgon2()
+	}
 }
 
 func encryptionKey(key string) (string, error) {

--- a/cmd/yopass/main.go
+++ b/cmd/yopass/main.go
@@ -178,9 +178,11 @@ func encryptFileByName(filename string, out io.Writer) error {
 		return fmt.Errorf("Failed to get file info: %w", err)
 	}
 
-	configureArgon2()
-
-	data, err := yopass.EncryptBinary(in, key, stat.Name())
+	encryptBinary := yopass.EncryptBinary
+	if argon2Enabled() {
+		encryptBinary = yopass.EncryptBinaryWithArgon2
+	}
+	data, err := encryptBinary(in, key, stat.Name())
 	if err != nil {
 		return fmt.Errorf("Failed to encrypt file: %w", err)
 	}
@@ -217,9 +219,11 @@ func encrypt(in io.ReadCloser, out io.Writer) error {
 		return fmt.Errorf("Failed to generate encryption key: %w", err)
 	}
 
-	configureArgon2()
-
-	msg, err := yopass.Encrypt(in, key)
+	encryptMessage := yopass.Encrypt
+	if argon2Enabled() {
+		encryptMessage = yopass.EncryptWithArgon2
+	}
+	msg, err := encryptMessage(in, key)
 	if err != nil {
 		return fmt.Errorf("Failed to encrypt secret: %w", err)
 	}
@@ -238,16 +242,14 @@ func encrypt(in io.ReadCloser, out io.Writer) error {
 	return err
 }
 
-// configureArgon2 reads the server /config endpoint and enables Argon2 key
-// derivation when the server has it enabled (--argon2). Errors are ignored
+// argon2Enabled reads the server /config endpoint and reports whether the
+// server has Argon2 key derivation enabled (--argon2). Errors are ignored
 // on purpose: if the config cannot be fetched the CLI falls back to the
 // default key derivation, which every yopass server accepts. Decryption
 // needs no configuration since the S2K type is stored in the message.
-func configureArgon2() {
+func argon2Enabled() bool {
 	config, err := yopass.FetchServerConfig(viper.GetString("api"))
-	if err == nil && config.Argon2 {
-		yopass.EnableArgon2()
-	}
+	return err == nil && config.Argon2
 }
 
 func encryptionKey(key string) (string, error) {

--- a/cmd/yopass/main_test.go
+++ b/cmd/yopass/main_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp/s2k"
 	"github.com/jhaals/yopass/pkg/server"
 	"github.com/jhaals/yopass/pkg/yopass"
 	"github.com/prometheus/client_golang/prometheus"
@@ -366,4 +369,116 @@ func (db *testDB) Update(key string, fn func(yopass.Secret) (yopass.Secret, erro
 
 func (db *testDB) Health() error {
 	return nil
+}
+
+// TestCLIArgon2 verifies that the CLI reads the server /config endpoint and
+// encrypts with Argon2 key derivation when the server has it enabled.
+//
+// Note: this test runs last in the file on purpose. Fetching an Argon2
+// enabled config switches the encryption settings in pkg/yopass for the
+// remainder of the process; the earlier tests exercise the default path.
+func TestCLIArgon2(t *testing.T) {
+	db := &testDB{data: make(map[string]yopass.Secret)}
+	y := server.Server{
+		DB:          db,
+		FileStore:   server.NewDatabaseFileStore(db),
+		MaxLength:   10000,
+		MaxFileSize: 10 * 1024 * 1024,
+		Registry:    prometheus.NewRegistry(),
+		Logger:      zaptest.NewLogger(t),
+		Argon2:      true,
+	}
+	ts := httptest.NewServer(y.HTTPHandler())
+	defer ts.Close()
+
+	// Reset viper to clear keys left behind by earlier tests (there is no
+	// way to unset a single key).
+	viper.Reset()
+	viper.Set("expiration", "1h")
+	viper.Set("one-time", true)
+	viper.Set("api", ts.URL)
+	viper.Set("url", ts.URL)
+	t.Cleanup(func() {
+		viper.Reset()
+		viper.Set("expiration", "1h")
+		viper.Set("one-time", true)
+		viper.Set("api", defaultAPI)
+		viper.Set("url", defaultURL)
+	})
+
+	msg := "yopass CLI argon2 test message"
+	stdin, err := tempFile(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(stdin.Name())
+	defer stdin.Close()
+
+	out := bytes.Buffer{}
+	if err := encryptStdinOrFile(stdin, &out); err != nil {
+		t.Fatalf("expected no encryption error, got %q", err)
+	}
+
+	// The stored ciphertext must use Argon2 key derivation.
+	if len(db.data) != 1 {
+		t.Fatalf("expected one stored secret, got %d", len(db.data))
+	}
+	for _, secret := range db.data {
+		if mode := messageS2KMode(t, secret.Message); mode != s2k.Argon2S2K {
+			t.Errorf("expected S2K mode %d (Argon2), got %d", s2k.Argon2S2K, mode)
+		}
+	}
+
+	viper.Set("decrypt", out.String())
+	out.Reset()
+	if err := decrypt(&out); err != nil {
+		t.Fatalf("expected no decryption error, got %q", err)
+	}
+	if out.String() != msg {
+		t.Fatalf("expected secret to match original %q, got %q", msg, out.String())
+	}
+}
+
+// messageS2KMode extracts the S2K mode from the leading symmetric-key
+// encrypted session key (SKESK) packet of an armored PGP message.
+func messageS2KMode(t *testing.T, msg string) s2k.Mode {
+	t.Helper()
+
+	block, err := armor.Decode(strings.NewReader(msg))
+	if err != nil {
+		t.Fatalf("could not decode armor: %v", err)
+	}
+	raw, err := io.ReadAll(block.Body)
+	if err != nil {
+		t.Fatalf("could not read message body: %v", err)
+	}
+	if len(raw) < 8 {
+		t.Fatalf("message too short: %d bytes", len(raw))
+	}
+
+	// New-format packet header, tag 3 is the SKESK packet. The packet is
+	// small enough that a single length octet follows the tag.
+	if raw[0] != 0xc3 {
+		t.Fatalf("expected message to start with a SKESK packet, got header byte %#x", raw[0])
+	}
+	body := raw[2:]
+
+	// The S2K specifier position depends on the SKESK version (RFC 9580
+	// section 5.3). Version 4: cipher octet, then S2K. Version 6: octet
+	// count, cipher, AEAD mode and S2K length octets, then S2K.
+	var s2kBytes []byte
+	switch version := body[0]; version {
+	case 4:
+		s2kBytes = body[2:]
+	case 6:
+		s2kBytes = body[5 : 5+int(body[4])]
+	default:
+		t.Fatalf("unexpected SKESK version %d", version)
+	}
+
+	params, err := s2k.ParseIntoParams(bytes.NewReader(s2kBytes))
+	if err != nil {
+		t.Fatalf("could not parse S2K params: %v", err)
+	}
+	return params.Mode()
 }

--- a/cmd/yopass/main_test.go
+++ b/cmd/yopass/main_test.go
@@ -18,16 +18,24 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
+// resetViper wipes all viper state, including keys a test has set that
+// cannot be unset individually (e.g. "key", "file", "decrypt"), and restores
+// the defaults from init() so tests stay independent of execution order.
+func resetViper() {
+	viper.Reset()
+	viper.SetDefault("api", defaultAPI)
+	viper.SetDefault("url", defaultURL)
+	viper.SetDefault("one-time", true)
+	viper.SetDefault("expiration", "1h")
+}
+
 func TestCLI(t *testing.T) {
 	ts, cleanup := newTestServer(t)
 	defer cleanup()
 
 	viper.Set("api", ts.URL)
 	viper.Set("url", ts.URL)
-	t.Cleanup(func() {
-		viper.Set("api", defaultAPI)
-		viper.Set("url", defaultURL)
-	})
+	t.Cleanup(resetViper)
 
 	msg := "yopass CLI integration test message"
 	stdin, err := tempFile(msg)
@@ -72,6 +80,7 @@ func TestInvalidExpiration(t *testing.T) {
 
 func TestMissingFileEncryption(t *testing.T) {
 	viper.Set("file", "xyz")
+	t.Cleanup(resetViper)
 	err := encryptStdinOrFile(nil, nil)
 	if err == nil {
 		t.Fatal("expected file open error, got none")
@@ -110,10 +119,7 @@ func TestCLIFileUpload(t *testing.T) {
 
 	viper.Set("api", ts.URL)
 	viper.Set("url", ts.URL)
-	t.Cleanup(func() {
-		viper.Set("api", defaultAPI)
-		viper.Set("url", defaultURL)
-	})
+	t.Cleanup(resetViper)
 
 	msg := "yopass CLI integration test file upload"
 	file, err := tempFile(msg)
@@ -188,11 +194,7 @@ func TestSecretNotFoundError(t *testing.T) {
 
 	viper.Set("api", ts.URL)
 	viper.Set("url", ts.URL)
-	t.Cleanup(func() {
-		viper.Set("api", defaultAPI)
-		viper.Set("url", defaultURL)
-		viper.Set("key", "")
-	})
+	t.Cleanup(resetViper)
 
 	viper.Set("decrypt", ts.URL+"/#/c/21701b28-fb3f-451d-8a52-3e6c9094e701")
 	viper.Set("key", "woo")
@@ -372,11 +374,9 @@ func (db *testDB) Health() error {
 }
 
 // TestCLIArgon2 verifies that the CLI reads the server /config endpoint and
-// encrypts with Argon2 key derivation when the server has it enabled.
-//
-// Note: this test runs last in the file on purpose. Fetching an Argon2
-// enabled config switches the encryption settings in pkg/yopass for the
-// remainder of the process; the earlier tests exercise the default path.
+// encrypts with Argon2 key derivation when the server has it enabled. The
+// Argon2 choice is made per encryption call and never alters process-wide
+// state, so this test is independent of test execution order.
 func TestCLIArgon2(t *testing.T) {
 	db := &testDB{data: make(map[string]yopass.Secret)}
 	y := server.Server{
@@ -391,20 +391,11 @@ func TestCLIArgon2(t *testing.T) {
 	ts := httptest.NewServer(y.HTTPHandler())
 	defer ts.Close()
 
-	// Reset viper to clear keys left behind by earlier tests (there is no
-	// way to unset a single key).
-	viper.Reset()
-	viper.Set("expiration", "1h")
-	viper.Set("one-time", true)
+	// Clear keys possibly left behind by earlier tests before setting up.
+	resetViper()
 	viper.Set("api", ts.URL)
 	viper.Set("url", ts.URL)
-	t.Cleanup(func() {
-		viper.Reset()
-		viper.Set("expiration", "1h")
-		viper.Set("one-time", true)
-		viper.Set("api", defaultAPI)
-		viper.Set("url", defaultURL)
-	})
+	t.Cleanup(resetViper)
 
 	msg := "yopass CLI argon2 test message"
 	stdin, err := tempFile(msg)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,6 +52,12 @@ cat secret-notes.md | yopass --expiration=1d --one-time=false
 yopass --decrypt https://yopass.se/#/...
 ```
 
+## Argon2 key derivation
+
+Before encrypting, the CLI reads the server's `/config` endpoint. When the server runs with [`--argon2`](./server-options#argon2-key-derivation), the CLI automatically uses Argon2id key derivation so secrets match the server's policy — no CLI flag is needed. If the config cannot be fetched, the CLI falls back to the default key derivation, which every yopass server accepts.
+
+Decryption needs no configuration in either case: the key derivation type is stored inside the encrypted message.
+
 ## Custom server
 
 To use a self-hosted instance, set both `--api` and `--url`:

--- a/docs/server-options.md
+++ b/docs/server-options.md
@@ -46,6 +46,37 @@ Complete reference for `yopass-server`. All flags can also be set via environmen
 | `--force-expiration` | `FORCE_EXPIRATION` | — | Force all secrets and file uploads to a fixed expiration: `1h`, `1d`, or `1w`. The server rejects any create request with a different value (`400 Expiration does not match server policy`). The UI replaces the expiration selector with the fixed duration |
 | `--force-onetime-secrets` | `FORCE_ONETIME_SECRETS` | `false` | Reject secrets that are not set to one-time viewing |
 | `--prefetch-secret` | `PREFETCH_SECRET` | `true` | Show a warning that the secret may be one-time use before revealing it |
+| `--argon2` | `ARGON2` | `false` | Use [Argon2id](https://datatracker.ietf.org/doc/rfc9106/) for password key derivation instead of iterated SHA-256. See [Argon2 key derivation](#argon2-key-derivation) |
+
+### Argon2 key derivation
+
+The `--argon2` flag switches the S2K (string-to-key) function used when encrypting secrets from the default iterated SHA-256 to Argon2id, a memory-hard function that better resists GPU-accelerated brute-force attacks. This mostly matters for user-chosen passwords; auto-generated keys are random and already infeasible to brute-force.
+
+When enabled, the server:
+
+- Exposes `ARGON2: true` in the `/config` endpoint, so the web frontend and the [CLI](./cli) encrypt with Argon2
+- Adds `'wasm-unsafe-eval'` to the `Content-Security-Policy` `script-src` directive, required by the WASM-based Argon2 implementation in OpenPGP.js
+
+```bash
+yopass-server --argon2
+
+# or via environment variable
+ARGON2=true yopass-server
+```
+
+Decryption is unaffected by the flag in either direction: the key derivation type is stored inside each PGP message, so secrets created before enabling (or after disabling) the flag keep working.
+
+:::warning CSP and reverse proxies
+
+The feature is opt-in because it loosens the Content-Security-Policy, and because reverse proxies that **override** the `Content-Security-Policy` header will silently break decryption in the browser. If your proxy (Nginx, Caddy, Apache, …) sets its own CSP, add `'wasm-unsafe-eval'` to `script-src`:
+
+```
+Content-Security-Policy: ... script-src 'self' 'wasm-unsafe-eval'; ...
+```
+
+`'wasm-unsafe-eval'` is a [CSP Level 3](https://www.w3.org/TR/CSP3/) source keyword that only permits WebAssembly compilation — it does **not** enable `eval()` or `Function()`. Proxies that pass backend headers through unchanged need no configuration.
+
+:::
 
 ---
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -44,6 +44,7 @@ type Server struct {
 	Webhooks *WebhookNotifier
 
 	// Feature toggles
+	Argon2                bool
 	ReadOnly              bool
 	DisableUpload         bool
 	PrefetchSecret        bool
@@ -363,6 +364,7 @@ func (y *Server) configHandler(w http.ResponseWriter, r *http.Request) {
 		"NO_LANGUAGE_SWITCHER":  y.NoLanguageSwitcher,
 		"FORCE_ONETIME_SECRETS": y.ForceOneTimeSecrets,
 		"DEFAULT_EXPIRY":        expirationInSeconds(y.DefaultExpiry),
+		"ARGON2":                y.Argon2,
 	}
 	if y.ForceExpiration != "" {
 		config["FORCE_EXPIRATION"] = expirationInSeconds(y.ForceExpiration)
@@ -615,7 +617,7 @@ func (y *Server) HTTPHandler() http.Handler {
 			extraImgSrc = []string{u.Scheme + "://" + u.Host}
 		}
 	}
-	return handlers.CustomLoggingHandler(nil, SecurityHeadersHandler(extraImgSrc, mx), y.httpLogFormatter())
+	return handlers.CustomLoggingHandler(nil, SecurityHeadersHandler(extraImgSrc, y.Argon2, mx), y.httpLogFormatter())
 }
 
 const keyParameter = "{key:(?:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}|[a-zA-Z0-9]{22})}"
@@ -692,15 +694,22 @@ func (y *Server) corsMiddleware(next http.Handler) http.Handler {
 // SecurityHeadersHandler returns a middleware which sets common security
 // HTTP headers on the response to mitigate common web vulnerabilities.
 // extraImgSrc extends the img-src CSP directive with additional allowed origins.
-func SecurityHeadersHandler(extraImgSrc []string, next http.Handler) http.Handler {
+// argon2 adds 'wasm-unsafe-eval' to script-src, required by the WASM-based
+// Argon2 implementation in OpenPGP.js. It permits WebAssembly compilation
+// only and does not enable eval() or Function().
+func SecurityHeadersHandler(extraImgSrc []string, argon2 bool, next http.Handler) http.Handler {
 	imgSrc := append([]string{"'self'", "data:"}, extraImgSrc...)
+	scriptSrc := "script-src 'self'"
+	if argon2 {
+		scriptSrc += " 'wasm-unsafe-eval'"
+	}
 	csp := []string{
 		"default-src 'self'",
 		"font-src 'self' data:",
 		"form-action 'self'",
 		"frame-ancestors 'none'",
 		"img-src " + strings.Join(imgSrc, " "),
-		"script-src 'self'",
+		scriptSrc,
 		"style-src 'self' 'unsafe-inline'",
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -474,6 +475,46 @@ func TestSecurityHeaders(t *testing.T) {
 	}
 }
 
+func TestSecurityHeadersArgon2(t *testing.T) {
+	tt := []struct {
+		name          string
+		argon2        bool
+		wantScriptSrc string
+	}{
+		{
+			name:          "argon2 disabled (default) keeps script-src restricted",
+			argon2:        false,
+			wantScriptSrc: "script-src 'self'",
+		},
+		{
+			name:          "argon2 enabled adds wasm-unsafe-eval to script-src",
+			argon2:        true,
+			wantScriptSrc: "script-src 'self' 'wasm-unsafe-eval'",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			y := newTestServer(t, &mockDB{}, 1, false)
+			y.Argon2 = tc.argon2
+			h := y.HTTPHandler()
+
+			req, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			csp := rr.Header().Get("content-security-policy")
+			directives := strings.Split(csp, "; ")
+			if !slices.Contains(directives, tc.wantScriptSrc) {
+				t.Errorf("Expected CSP to contain %q, got %q", tc.wantScriptSrc, csp)
+			}
+		})
+	}
+}
+
 func TestSecurityHeadersExternalLogoURL(t *testing.T) {
 	tt := []struct {
 		name       string
@@ -540,6 +581,29 @@ func TestConfigHandler(t *testing.T) {
 
 	if got, want := config["DISABLE_UPLOAD"].(bool), true; got != want {
 		t.Errorf("Expected DISABLE_UPLOAD to be %v, got %v", want, got)
+	}
+	if got, want := config["ARGON2"].(bool), false; got != want {
+		t.Errorf("Expected ARGON2 to be %v, got %v", want, got)
+	}
+}
+
+func TestConfigHandlerArgon2(t *testing.T) {
+	server := newTestServer(t, &mockDB{}, 1, false)
+	server.Argon2 = true
+
+	req := httptest.NewRequest(http.MethodGet, "/config", nil)
+	w := httptest.NewRecorder()
+	server.configHandler(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	var config map[string]interface{}
+	if err := json.NewDecoder(res.Body).Decode(&config); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if got, want := config["ARGON2"].(bool), true; got != want {
+		t.Errorf("Expected ARGON2 to be %v, got %v", want, got)
 	}
 }
 

--- a/pkg/yopass/argon2_test.go
+++ b/pkg/yopass/argon2_test.go
@@ -23,6 +23,14 @@ func messageS2KMode(t *testing.T, msg string) s2k.Mode {
 	if err != nil {
 		t.Fatalf("could not read message body: %v", err)
 	}
+	return packetS2KMode(t, raw)
+}
+
+// packetS2KMode extracts the S2K mode from the leading symmetric-key
+// encrypted session key (SKESK) packet of a binary PGP message.
+func packetS2KMode(t *testing.T, raw []byte) s2k.Mode {
+	t.Helper()
+
 	if len(raw) < 8 {
 		t.Fatalf("message too short: %d bytes", len(raw))
 	}
@@ -54,12 +62,9 @@ func messageS2KMode(t *testing.T, msg string) s2k.Mode {
 	return params.Mode()
 }
 
-func TestEnableArgon2(t *testing.T) {
-	EnableArgon2()
-	t.Cleanup(func() { pgpConfig.S2KConfig = nil })
-
+func TestEncryptWithArgon2(t *testing.T) {
 	const secret = "argon2 secret"
-	msg, err := Encrypt(strings.NewReader(secret), "test-key")
+	msg, err := EncryptWithArgon2(strings.NewReader(secret), "test-key")
 	if err != nil {
 		t.Fatalf("expected no encryption error, got %v", err)
 	}
@@ -75,6 +80,44 @@ func TestEnableArgon2(t *testing.T) {
 	}
 	if content != secret {
 		t.Errorf("expected decrypted content %q, got %q", secret, content)
+	}
+}
+
+func TestEncryptBinaryWithArgon2(t *testing.T) {
+	const secret = "argon2 binary secret"
+	data, err := EncryptBinaryWithArgon2(strings.NewReader(secret), "test-key", "secret.txt")
+	if err != nil {
+		t.Fatalf("expected no encryption error, got %v", err)
+	}
+	if mode := packetS2KMode(t, data); mode != s2k.Argon2S2K {
+		t.Errorf("expected S2K mode %d (Argon2), got %d", s2k.Argon2S2K, mode)
+	}
+
+	content, filename, err := Decrypt(bytes.NewReader(data), "test-key")
+	if err != nil {
+		t.Fatalf("expected no decryption error, got %v", err)
+	}
+	if content != secret {
+		t.Errorf("expected decrypted content %q, got %q", secret, content)
+	}
+	if filename != "secret.txt" {
+		t.Errorf("expected filename %q, got %q", "secret.txt", filename)
+	}
+}
+
+// TestArgon2DoesNotStick guards against the Argon2 option leaking into
+// subsequent default encryption within the same process.
+func TestArgon2DoesNotStick(t *testing.T) {
+	if _, err := EncryptWithArgon2(strings.NewReader("argon2 secret"), "test-key"); err != nil {
+		t.Fatalf("expected no encryption error, got %v", err)
+	}
+
+	msg, err := Encrypt(strings.NewReader("default secret"), "test-key")
+	if err != nil {
+		t.Fatalf("expected no encryption error, got %v", err)
+	}
+	if mode := messageS2KMode(t, msg); mode != s2k.IteratedSaltedS2K {
+		t.Errorf("expected S2K mode %d (iterated and salted), got %d", s2k.IteratedSaltedS2K, mode)
 	}
 }
 

--- a/pkg/yopass/argon2_test.go
+++ b/pkg/yopass/argon2_test.go
@@ -1,0 +1,89 @@
+package yopass
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp/s2k"
+)
+
+// messageS2KMode extracts the S2K mode from the leading symmetric-key
+// encrypted session key (SKESK) packet of an armored PGP message.
+func messageS2KMode(t *testing.T, msg string) s2k.Mode {
+	t.Helper()
+
+	block, err := armor.Decode(strings.NewReader(msg))
+	if err != nil {
+		t.Fatalf("could not decode armor: %v", err)
+	}
+	raw, err := io.ReadAll(block.Body)
+	if err != nil {
+		t.Fatalf("could not read message body: %v", err)
+	}
+	if len(raw) < 8 {
+		t.Fatalf("message too short: %d bytes", len(raw))
+	}
+
+	// New-format packet header, tag 3 is the SKESK packet. The packet is
+	// small enough that a single length octet follows the tag.
+	if raw[0] != 0xc3 {
+		t.Fatalf("expected message to start with a SKESK packet, got header byte %#x", raw[0])
+	}
+	body := raw[2:]
+
+	// The S2K specifier position depends on the SKESK version (RFC 9580
+	// section 5.3). Version 4: cipher octet, then S2K. Version 6: octet
+	// count, cipher, AEAD mode and S2K length octets, then S2K.
+	var s2kBytes []byte
+	switch version := body[0]; version {
+	case 4:
+		s2kBytes = body[2:]
+	case 6:
+		s2kBytes = body[5 : 5+int(body[4])]
+	default:
+		t.Fatalf("unexpected SKESK version %d", version)
+	}
+
+	params, err := s2k.ParseIntoParams(bytes.NewReader(s2kBytes))
+	if err != nil {
+		t.Fatalf("could not parse S2K params: %v", err)
+	}
+	return params.Mode()
+}
+
+func TestEnableArgon2(t *testing.T) {
+	EnableArgon2()
+	t.Cleanup(func() { pgpConfig.S2KConfig = nil })
+
+	const secret = "argon2 secret"
+	msg, err := Encrypt(strings.NewReader(secret), "test-key")
+	if err != nil {
+		t.Fatalf("expected no encryption error, got %v", err)
+	}
+	if mode := messageS2KMode(t, msg); mode != s2k.Argon2S2K {
+		t.Errorf("expected S2K mode %d (Argon2), got %d", s2k.Argon2S2K, mode)
+	}
+
+	// Decryption reads the S2K type from the message and needs no
+	// configuration.
+	content, _, err := Decrypt(strings.NewReader(msg), "test-key")
+	if err != nil {
+		t.Fatalf("expected no decryption error, got %v", err)
+	}
+	if content != secret {
+		t.Errorf("expected decrypted content %q, got %q", secret, content)
+	}
+}
+
+func TestDefaultS2KModeIsIterated(t *testing.T) {
+	msg, err := Encrypt(strings.NewReader("default secret"), "test-key")
+	if err != nil {
+		t.Fatalf("expected no encryption error, got %v", err)
+	}
+	if mode := messageS2KMode(t, msg); mode != s2k.IteratedSaltedS2K {
+		t.Errorf("expected S2K mode %d (iterated and salted), got %d", s2k.IteratedSaltedS2K, mode)
+	}
+}

--- a/pkg/yopass/client.go
+++ b/pkg/yopass/client.go
@@ -29,6 +29,34 @@ type serverResponse struct {
 	Message string `json:"message"`
 }
 
+// ServerConfig holds the subset of the server /config response relevant to
+// the CLI client. Unknown fields are ignored so older servers remain
+// compatible.
+type ServerConfig struct {
+	Argon2 bool `json:"ARGON2"`
+}
+
+// FetchServerConfig retrieves the public configuration from the specified
+// server's /config endpoint.
+func FetchServerConfig(server string) (ServerConfig, error) {
+	server = strings.TrimSuffix(server, "/")
+
+	var config ServerConfig
+	resp, err := HTTPClient.Get(server + "/config")
+	if err != nil {
+		return config, &ServerError{err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return config, &ServerError{err: fmt.Errorf("unexpected response %s", resp.Status)}
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
+		return config, fmt.Errorf("could not decode server config: %w", err)
+	}
+	return config, nil
+}
+
 // Fetch retrieves a secret by its ID from the specified server.
 func Fetch(server string, id string) (string, error) {
 	server = strings.TrimSuffix(server, "/")

--- a/pkg/yopass/client_test.go
+++ b/pkg/yopass/client_test.go
@@ -213,6 +213,41 @@ func TestFetchFileNotFound(t *testing.T) {
 	}
 }
 
+func TestFetchServerConfig(t *testing.T) {
+	for _, argon2 := range []bool{false, true} {
+		db := testDB(map[string]string{})
+		y := server.Server{
+			DB:        &db,
+			FileStore: server.NewDatabaseFileStore(&db),
+			MaxLength: 10000,
+			Registry:  prometheus.NewRegistry(),
+			Logger:    zaptest.NewLogger(t),
+			Argon2:    argon2,
+		}
+		ts := httptest.NewServer(y.HTTPHandler())
+		defer ts.Close()
+
+		config, err := yopass.FetchServerConfig(ts.URL)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if config.Argon2 != argon2 {
+			t.Errorf("expected Argon2 to be %v, got %v", argon2, config.Argon2)
+		}
+	}
+}
+
+func TestFetchServerConfigError(t *testing.T) {
+	_, err := yopass.FetchServerConfig("http://127.0.0.1:1/invalid")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var serverErr *yopass.ServerError
+	if !errors.As(err, &serverErr) {
+		t.Fatalf("expected ServerError, got %T", err)
+	}
+}
+
 func TestStoreFileServerError(t *testing.T) {
 	_, err := yopass.StoreFile("http://127.0.0.1:1/invalid", []byte("data"), 3600, true)
 	if err == nil {

--- a/pkg/yopass/yopass.go
+++ b/pkg/yopass/yopass.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp/s2k"
 )
 
 // ErrEmptyKey is returned when no encryption key is provided.
@@ -37,6 +38,13 @@ var pgpConfig = &packet.Config{
 
 var pgpHeader = map[string]string{
 	"Comment": "https://yopass.se",
+}
+
+// EnableArgon2 switches S2K key derivation from the default iterated SHA-256
+// to memory-hard Argon2id for all subsequent encryption. Decryption is
+// unaffected as the S2K type is stored in the PGP message itself.
+func EnableArgon2() {
+	pgpConfig.S2KConfig = &s2k.Config{S2KMode: s2k.Argon2S2K}
 }
 
 // Secret holds the encrypted message

--- a/pkg/yopass/yopass.go
+++ b/pkg/yopass/yopass.go
@@ -40,12 +40,15 @@ var pgpHeader = map[string]string{
 	"Comment": "https://yopass.se",
 }
 
-// EnableArgon2 switches S2K key derivation from the default iterated SHA-256
-// to memory-hard Argon2id for all subsequent encryption. Decryption is
-// unaffected as the S2K type is stored in the PGP message itself.
-func EnableArgon2() {
-	pgpConfig.S2KConfig = &s2k.Config{S2KMode: s2k.Argon2S2K}
-}
+// pgpConfigArgon2 mirrors pgpConfig with S2K key derivation switched from
+// the default iterated SHA-256 to memory-hard Argon2id. It is a separate
+// config so the Argon2 choice is made per encryption call and never leaks
+// into unrelated encryption in the same process.
+var pgpConfigArgon2 = func() *packet.Config {
+	cfg := *pgpConfig
+	cfg.S2KConfig = &s2k.Config{S2KMode: s2k.Argon2S2K}
+	return &cfg
+}()
 
 // Secret holds the encrypted message
 type Secret struct {
@@ -113,6 +116,18 @@ const armorHeader = "-----BEGIN PGP MESSAGE-----"
 // EncryptBinary encrypts the data from r as binary PGP (no ASCII armor).
 // This format is used for streaming file uploads.
 func EncryptBinary(r io.Reader, key string, filename string) ([]byte, error) {
+	return encryptBinary(r, key, filename, pgpConfig)
+}
+
+// EncryptBinaryWithArgon2 is EncryptBinary with memory-hard Argon2id key
+// derivation instead of the default iterated SHA-256. Only use it against
+// servers that advertise Argon2 support (see FetchServerConfig). Decryption
+// needs no counterpart as the S2K type is stored in the PGP message itself.
+func EncryptBinaryWithArgon2(r io.Reader, key string, filename string) ([]byte, error) {
+	return encryptBinary(r, key, filename, pgpConfigArgon2)
+}
+
+func encryptBinary(r io.Reader, key string, filename string, config *packet.Config) ([]byte, error) {
 	if key == "" {
 		return nil, ErrEmptyKey
 	}
@@ -123,7 +138,7 @@ func EncryptBinary(r io.Reader, key string, filename string) ([]byte, error) {
 	}
 
 	buf := new(bytes.Buffer)
-	w, err := openpgp.SymmetricallyEncrypt(buf, []byte(key), hints, pgpConfig)
+	w, err := openpgp.SymmetricallyEncrypt(buf, []byte(key), hints, config)
 	if err != nil {
 		return nil, fmt.Errorf("could not encrypt: %w", err)
 	}
@@ -141,6 +156,18 @@ func EncryptBinary(r io.Reader, key string, filename string) ([]byte, error) {
 // the given key. No assumptions about the ciphertext format should be made, the
 // encryption method might change in future versions.
 func Encrypt(r io.Reader, key string) (string, error) {
+	return encrypt(r, key, pgpConfig)
+}
+
+// EncryptWithArgon2 is Encrypt with memory-hard Argon2id key derivation
+// instead of the default iterated SHA-256. Only use it against servers that
+// advertise Argon2 support (see FetchServerConfig). Decryption needs no
+// counterpart as the S2K type is stored in the PGP message itself.
+func EncryptWithArgon2(r io.Reader, key string) (string, error) {
+	return encrypt(r, key, pgpConfigArgon2)
+}
+
+func encrypt(r io.Reader, key string, config *packet.Config) (string, error) {
 	if key == "" {
 		return "", ErrEmptyKey
 	}
@@ -163,7 +190,7 @@ func Encrypt(r io.Reader, key string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not create armor encoder: %w", err)
 	}
-	w, err := openpgp.SymmetricallyEncrypt(a, []byte(key), hints, pgpConfig)
+	w, err := openpgp.SymmetricallyEncrypt(a, []byte(key), hints, config)
 	if err != nil {
 		return "", fmt.Errorf("could not encrypt: %w", err)
 	}

--- a/website/src/features/CreateSecret.tsx
+++ b/website/src/features/CreateSecret.tsx
@@ -58,7 +58,7 @@ export default function CreateSecret() {
     const { data, status } = await postSecret(
       {
         expiration: parseInt(form.expiration),
-        message: await encryptMessage(form.secret, pw),
+        message: await encryptMessage(form.secret, pw, config?.ARGON2),
         one_time: config?.FORCE_ONETIME_SECRETS || oneTime,
         require_auth: requireAuth,
         receipt: config?.READ_RECEIPTS && readReceipt,

--- a/website/src/features/StreamingUpload.tsx
+++ b/website/src/features/StreamingUpload.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { encrypt, createMessage } from 'openpgp';
-import { encryptionConfig } from '@shared/lib/crypto';
+import { getEncryptionConfig } from '@shared/lib/crypto';
 import { uploadStreamingFile } from '@shared/lib/api';
 import { saveNewReceipt } from '@shared/lib/receiptStore';
 import { parseSize } from '@shared/lib/parseSize';
@@ -103,7 +103,7 @@ export default function StreamingUpload() {
       const encrypted = await encrypt({
         message,
         passwords: pw,
-        config: encryptionConfig,
+        config: getEncryptionConfig(config?.ARGON2),
         format: 'binary',
       });
 

--- a/website/src/shared/context/ConfigContext.tsx
+++ b/website/src/shared/context/ConfigContext.tsx
@@ -26,6 +26,7 @@ export interface Config {
   REQUIRE_AUTH: boolean;
   SECRET_REQUESTS: boolean;
   READ_RECEIPTS: boolean;
+  ARGON2: boolean;
 }
 
 const defaultConfig: Config = {
@@ -41,6 +42,7 @@ const defaultConfig: Config = {
   REQUIRE_AUTH: false,
   SECRET_REQUESTS: false,
   READ_RECEIPTS: false,
+  ARGON2: false,
 };
 
 type GlobalWithCache = typeof globalThis & {
@@ -140,6 +142,7 @@ async function loadConfig(): Promise<Config> {
             : false,
         READ_RECEIPTS:
           typeof data.READ_RECEIPTS === 'boolean' ? data.READ_RECEIPTS : false,
+        ARGON2: typeof data.ARGON2 === 'boolean' ? data.ARGON2 : false,
       };
       configCache = parsed;
       g.__yopassConfigCache = parsed;

--- a/website/src/shared/lib/crypto.ts
+++ b/website/src/shared/lib/crypto.ts
@@ -28,11 +28,25 @@ export async function decryptMessage(
   });
 }
 
-export async function encryptMessage(data: string, passwords: string) {
+// Returns the encryption config, optionally with Argon2 key derivation.
+// Argon2 is opt-in (server flag --argon2) because its WASM implementation
+// requires the 'wasm-unsafe-eval' CSP directive.
+export function getEncryptionConfig(argon2?: boolean): Partial<Config> {
+  if (argon2) {
+    return { ...encryptionConfig, s2kType: enums.s2k.argon2 };
+  }
+  return encryptionConfig;
+}
+
+export async function encryptMessage(
+  data: string,
+  passwords: string,
+  argon2?: boolean,
+) {
   return encrypt({
     message: await createMessage({ text: data }),
     passwords,
-    config: encryptionConfig,
+    config: getEncryptionConfig(argon2),
   });
 }
 

--- a/website/tests/argon2.spec.ts
+++ b/website/tests/argon2.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import { readMessage, decrypt, enums } from 'openpgp';
+import { MockAPI } from './helpers/mock-api';
+import { testSecrets, mockResponses } from './helpers/test-data';
+
+// Extracts the S2K (key derivation) type from the symmetric-key encrypted
+// session key packet of an armored PGP message.
+async function messageS2KType(armoredMessage: string): Promise<string> {
+  const message = await readMessage({ armoredMessage });
+  const skesk = message.packets.filterByTag(
+    enums.packet.symEncryptedSessionKey,
+  )[0] as unknown as { s2k: { type: string } };
+  return skesk.s2k.type;
+}
+
+async function createSecretAndCapturePayload(
+  page: import('@playwright/test').Page,
+  mockAPI: MockAPI,
+): Promise<{ message: string; oneClickLink: string }> {
+  await mockAPI.mockCreateSecret(mockResponses.secretCreated);
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  await page.fill(
+    'textarea[placeholder="Enter your secret..."]',
+    testSecrets.simple.message,
+  );
+  await page.click('button[type="submit"]');
+  await expect(
+    page.locator('h2:has-text("Secret stored securely")'),
+  ).toBeVisible();
+
+  const lastRequest = mockAPI.getLastRequest('/secret');
+  expect(lastRequest).toBeDefined();
+  const payload = lastRequest?.payload as { message: string };
+
+  const oneClickLink = await page
+    .locator('code', { hasText: '/#/s/' })
+    .first()
+    .innerText();
+
+  return { message: payload.message, oneClickLink };
+}
+
+test.describe('Argon2 key derivation', () => {
+  let mockAPI: MockAPI;
+
+  test.beforeEach(async ({ page }) => {
+    mockAPI = new MockAPI(page);
+  });
+
+  test.afterEach(async () => {
+    await mockAPI.clearAllMocks();
+  });
+
+  test('encrypts with argon2 when the server enables ARGON2', async ({
+    page,
+  }) => {
+    await mockAPI.mockConfigEndpoint({ ARGON2: true });
+    const { message, oneClickLink } = await createSecretAndCapturePayload(
+      page,
+      mockAPI,
+    );
+
+    expect(await messageS2KType(message)).toBe('argon2');
+
+    // The ciphertext must decrypt with the key from the generated link.
+    const key = oneClickLink.split('/').pop() as string;
+    const decrypted = await decrypt({
+      message: await readMessage({ armoredMessage: message }),
+      passwords: key,
+    });
+    expect(decrypted.data).toBe(testSecrets.simple.message);
+  });
+
+  test('uses the default key derivation when ARGON2 is not enabled', async ({
+    page,
+  }) => {
+    await mockAPI.mockConfigEndpoint();
+    const { message } = await createSecretAndCapturePayload(page, mockAPI);
+
+    expect(await messageS2KType(message)).toBe('iterated');
+  });
+});

--- a/website/tests/helpers/mock-api.ts
+++ b/website/tests/helpers/mock-api.ts
@@ -214,6 +214,7 @@ export class MockAPI {
     THEME_CUSTOM_DARK?: Record<string, string>;
     APP_NAME?: string;
     PUBLIC_URL?: string;
+    ARGON2?: boolean;
   }) {
     const defaultConfig = {
       DISABLE_UPLOAD: false,


### PR DESCRIPTION
Replace iterated SHA-256 with memory-hard Argon2id for S2K key derivation when the server runs with --argon2 (default off). The flag is opt-in because the WASM-based Argon2 implementation in OpenPGP.js requires the 'wasm-unsafe-eval' CSP directive, which breaks on reverse proxies that override the Content-Security-Policy header.

When enabled the server exposes ARGON2 in /config and extends the CSP script-src directive automatically. The web frontend and the yopass CLI read /config and switch to Argon2 encryption accordingly; decryption is unaffected since the S2K type is stored in each PGP message.

This PR is based of the work by @ahenry-i-tracing. Fixes #3369 