### PR TITLE
Refactor yopass-server startup into testable functions; route Prefetcher through api.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ website/cypress/videos
 website/cypress/screenshots
 
 .idea
-yopass-server
+/yopass-server

--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -186,99 +186,23 @@ func main() {
 		os.Exit(0)
 	}
 
-	if v := viper.GetString("default-expiry"); v != "" && !server.ValidExpiryString(v) {
-		logger.Fatal("invalid --default-expiry value, expected one of: 1h, 1d, 1w",
-			zap.String("value", v))
-	}
-
-	switch viper.GetString("force-expiration") {
-	case "", "1h", "1d", "1w":
-		// valid
-	default:
-		logger.Fatal("invalid --force-expiration value, expected one of: 1h, 1d, 1w",
-			zap.String("value", viper.GetString("force-expiration")))
-	}
-
-	for _, flagName := range []string{"theme-light", "theme-dark"} {
-		val := viper.GetString(flagName)
-		if val == "custom-light" || val == "custom-dark" {
-			logger.Fatal(flagName+" must not be set to a reserved name",
-				zap.String("value", val),
-				zap.Strings("reserved", []string{"custom-light", "custom-dark"}))
-		}
-	}
-
-	for _, flagName := range []string{"theme-custom-light", "theme-custom-dark"} {
-		raw := viper.GetString(flagName)
-		if raw == "" {
-			continue
-		}
-		var vars map[string]string
-		if err := json.Unmarshal([]byte(raw), &vars); err != nil {
-			logger.Fatal("invalid JSON for "+flagName, zap.Error(err))
-		}
-		for k := range vars {
-			if !strings.HasPrefix(k, "--color-") {
-				logger.Fatal(flagName+" contains invalid CSS variable key (must start with --color-)",
-					zap.String("key", k))
-			}
-		}
-	}
-
 	registry := setupRegistry()
+	licenseStatus := setupLicense(logger, registry)
 
-	licenseStatus := server.LicenseStatus{}
-	if licenseKey := viper.GetString("license-key"); licenseKey != "" {
-		licenseStatus = server.VerifyLicense(licenseKey, logger)
-		if licenseStatus.Valid {
-			logger.Info("license key verified",
-				zap.String("licensee", licenseStatus.Licensee),
-				zap.Time("expires_at", licenseStatus.ExpiresAt),
-				zap.Float64("days_until_expiry", licenseStatus.DaysUntilExpiry()),
-			)
-		}
-		daysGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "yopass_license_days_until_expiry",
-			Help: "Number of days until the license key expires; negative if expired",
-		})
-		registry.MustRegister(daysGauge)
-		daysGauge.Set(licenseStatus.DaysUntilExpiry())
+	if err := validateFlags(licenseStatus.Valid); err != nil {
+		logger.Fatal(err.Error())
 	}
 
-	var oidcProvider rp.RelyingParty
-	if licenseStatus.Valid && viper.GetString("oidc-issuer") != "" {
-		oidcCtx, oidcCancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer oidcCancel()
-		var oidcErr error
-		oidcProvider, oidcErr = server.NewOIDCProvider(oidcCtx, logger, server.OIDCConfig{
-			Issuer:       viper.GetString("oidc-issuer"),
-			ClientID:     viper.GetString("oidc-client-id"),
-			ClientSecret: viper.GetString("oidc-client-secret"),
-			RedirectURL:  viper.GetString("oidc-redirect-url"),
-			SessionKey:   viper.GetString("oidc-session-key"),
-		})
-		if oidcErr != nil {
-			logger.Fatal("failed to initialize OIDC provider", zap.Error(oidcErr))
-		}
-		logger.Info("OIDC authentication enabled",
-			zap.String("issuer", viper.GetString("oidc-issuer")),
-			zap.Bool("require_auth", viper.GetBool("require-auth")),
-		)
-	} else if viper.GetString("oidc-issuer") != "" && !licenseStatus.Valid {
-		logger.Fatal("--oidc-issuer is configured but no valid license key was provided — refusing to start without authentication (provide --license-key or remove --oidc-issuer)")
-	}
-	if viper.GetBool("require-auth") && oidcProvider == nil {
-		logger.Fatal("--require-auth is set but OIDC is not configured (check --oidc-issuer and --license-key)")
-	}
-
-	apiTokens, err := server.ParseAPITokens(getStringSliceCSV("api-token"))
+	oidcProvider, cookieCodec, err := setupOIDC(logger, licenseStatus.Valid)
 	if err != nil {
-		logger.Fatal("invalid --api-token", zap.Error(err))
+		logger.Fatal("failed to initialize OIDC provider", zap.Error(err))
+	}
+
+	apiTokens, err := resolveAPITokens()
+	if err != nil {
+		logger.Fatal(err.Error())
 	}
 	if len(apiTokens) > 0 {
-		if !viper.GetBool("require-auth") {
-			logger.Fatal("--api-token is set but --require-auth is not — API tokens only apply when creation requires authentication")
-		}
 		names := make([]string, len(apiTokens))
 		for i, t := range apiTokens {
 			names[i] = t.Name
@@ -286,70 +210,19 @@ func main() {
 		logger.Info("API token authentication enabled", zap.Strings("tokens", names))
 	}
 
-	var cookieCodec *securecookie.SecureCookie
-	if oidcProvider != nil {
-		sessionKey := viper.GetString("oidc-session-key")
-		if len(sessionKey) == 128 {
-			if _, err := hex.DecodeString(sessionKey); err != nil {
-				logger.Fatal("--oidc-session-key is 128 characters but not valid hex; generate with: openssl rand -hex 64")
-			}
-		} else if sessionKey != "" {
-			// NewCookieCodec silently falls back to random per-instance keys
-			// for any other length, which breaks sessions across instances
-			// and restarts — surface the misconfiguration loudly.
-			logger.Warn("--oidc-session-key is set but not 128 hex characters; falling back to random per-instance session keys — sessions will not survive restarts or work across multiple instances (generate with: openssl rand -hex 64)",
-				zap.Int("length", len(sessionKey)))
-		}
-		cookieCodec = server.NewCookieCodec(sessionKey)
-	}
-
-	var auditLogger server.AuditLogger = server.NewNoopAuditLogger()
-	if viper.GetBool("audit-log") {
-		if !licenseStatus.Valid {
-			logger.Fatal("--audit-log requires a valid license key")
-		}
-		al, err := server.NewAuditLogger(viper.GetString("audit-log-file"))
-		if err != nil {
-			logger.Fatal("failed to initialize audit logger", zap.Error(err))
-		}
-		auditLogger = al
-		output := viper.GetString("audit-log-file")
-		if output == "" {
-			output = "stdout"
-		}
-		logger.Info("audit logging enabled", zap.String("output", output))
-	}
-
-	var webhooks *server.WebhookNotifier
-	if webhookURL := viper.GetString("webhook-url"); webhookURL != "" {
-		if !licenseStatus.Valid {
-			logger.Fatal("--webhook-url requires a valid license key")
-		}
-		var whErr error
-		webhooks, whErr = server.NewWebhookNotifier(server.WebhookConfig{
-			URL:    webhookURL,
-			Secret: viper.GetString("webhook-secret"),
-		}, logger, registry)
-		if whErr != nil {
-			logger.Fatal("failed to initialize webhook notifier", zap.Error(whErr))
-		}
-		logger.Info("webhook notifications enabled",
-			zap.String("url", webhookURL),
-			zap.Bool("signed", viper.GetString("webhook-secret") != ""),
-		)
-	} else if viper.GetString("webhook-secret") != "" {
-		logger.Fatal("--webhook-secret is set but --webhook-url is not")
-	}
-
-	maxFileSize, err := server.ParseSize(viper.GetString("max-file-size"))
+	auditLogger, err := setupAuditLogger(logger)
 	if err != nil {
-		logger.Fatal("invalid --max-file-size value", zap.String("value", viper.GetString("max-file-size")), zap.Error(err))
+		logger.Fatal("failed to initialize audit logger", zap.Error(err))
 	}
-	const maxFileSizeCap int64 = 1 * 1024 * 1024 // 1MB
-	if !licenseStatus.Valid && maxFileSize > maxFileSizeCap {
-		logger.Warn("--max-file-size exceeds 1MB cap, capping to 1MB (a valid license removes this limit)",
-			zap.String("requested", viper.GetString("max-file-size")))
-		maxFileSize = maxFileSizeCap
+
+	webhooks, err := setupWebhooks(logger, registry)
+	if err != nil {
+		logger.Fatal("failed to initialize webhook notifier", zap.Error(err))
+	}
+
+	maxFileSize, err := resolveMaxFileSize(logger, licenseStatus.Valid)
+	if err != nil {
+		logger.Fatal(err.Error())
 	}
 
 	db, err := setupDatabase(logger)
@@ -488,6 +361,202 @@ func main() {
 		logger.Error("failed to flush audit log on shutdown", zap.Error(err))
 	}
 	logger.Info("Server shut down")
+}
+
+// validateFlags checks flag values and cross-flag requirements that need no
+// constructed dependencies, returning an error describing the first problem
+// found. licenseValid reports whether a valid --license-key was provided,
+// which gates the business features.
+func validateFlags(licenseValid bool) error {
+	if v := viper.GetString("default-expiry"); v != "" && !server.ValidExpiryString(v) {
+		return fmt.Errorf("invalid --default-expiry value %q, expected one of: 1h, 1d, 1w", v)
+	}
+
+	switch v := viper.GetString("force-expiration"); v {
+	case "", "1h", "1d", "1w":
+		// valid
+	default:
+		return fmt.Errorf("invalid --force-expiration value %q, expected one of: 1h, 1d, 1w", v)
+	}
+
+	for _, flagName := range []string{"theme-light", "theme-dark"} {
+		val := viper.GetString(flagName)
+		if val == "custom-light" || val == "custom-dark" {
+			return fmt.Errorf("--%s must not be set to the reserved name %q", flagName, val)
+		}
+	}
+
+	for _, flagName := range []string{"theme-custom-light", "theme-custom-dark"} {
+		raw := viper.GetString(flagName)
+		if raw == "" {
+			continue
+		}
+		var vars map[string]string
+		if err := json.Unmarshal([]byte(raw), &vars); err != nil {
+			return fmt.Errorf("invalid JSON for --%s: %w", flagName, err)
+		}
+		for k := range vars {
+			if !strings.HasPrefix(k, "--color-") {
+				return fmt.Errorf("--%s contains invalid CSS variable key %q (must start with --color-)", flagName, k)
+			}
+		}
+	}
+
+	if viper.GetString("oidc-issuer") != "" && !licenseValid {
+		return errors.New("--oidc-issuer is configured but no valid license key was provided — refusing to start without authentication (provide --license-key or remove --oidc-issuer)")
+	}
+
+	if viper.GetBool("require-auth") && (viper.GetString("oidc-issuer") == "" || !licenseValid) {
+		return errors.New("--require-auth is set but OIDC is not configured (check --oidc-issuer and --license-key)")
+	}
+
+	if key := viper.GetString("oidc-session-key"); len(key) == 128 {
+		if _, err := hex.DecodeString(key); err != nil {
+			return errors.New("--oidc-session-key is 128 characters but not valid hex; generate with: openssl rand -hex 64")
+		}
+	}
+
+	if viper.GetBool("audit-log") && !licenseValid {
+		return errors.New("--audit-log requires a valid license key")
+	}
+
+	if viper.GetString("webhook-url") != "" && !licenseValid {
+		return errors.New("--webhook-url requires a valid license key")
+	}
+	if viper.GetString("webhook-secret") != "" && viper.GetString("webhook-url") == "" {
+		return errors.New("--webhook-secret is set but --webhook-url is not")
+	}
+
+	return nil
+}
+
+// setupLicense verifies --license-key when provided and registers the
+// license expiry gauge on the registry.
+func setupLicense(logger *zap.Logger, registry *prometheus.Registry) server.LicenseStatus {
+	licenseStatus := server.LicenseStatus{}
+	if licenseKey := viper.GetString("license-key"); licenseKey != "" {
+		licenseStatus = server.VerifyLicense(licenseKey, logger)
+		if licenseStatus.Valid {
+			logger.Info("license key verified",
+				zap.String("licensee", licenseStatus.Licensee),
+				zap.Time("expires_at", licenseStatus.ExpiresAt),
+				zap.Float64("days_until_expiry", licenseStatus.DaysUntilExpiry()),
+			)
+		}
+		daysGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "yopass_license_days_until_expiry",
+			Help: "Number of days until the license key expires; negative if expired",
+		})
+		registry.MustRegister(daysGauge)
+		daysGauge.Set(licenseStatus.DaysUntilExpiry())
+	}
+	return licenseStatus
+}
+
+// setupOIDC creates the OIDC relying party and session cookie codec when
+// --oidc-issuer is configured. validateFlags has already rejected an issuer
+// without a valid license, so a nil provider simply means OIDC is off.
+func setupOIDC(logger *zap.Logger, licenseValid bool) (rp.RelyingParty, *securecookie.SecureCookie, error) {
+	if !licenseValid || viper.GetString("oidc-issuer") == "" {
+		return nil, nil, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	provider, err := server.NewOIDCProvider(ctx, logger, server.OIDCConfig{
+		Issuer:       viper.GetString("oidc-issuer"),
+		ClientID:     viper.GetString("oidc-client-id"),
+		ClientSecret: viper.GetString("oidc-client-secret"),
+		RedirectURL:  viper.GetString("oidc-redirect-url"),
+		SessionKey:   viper.GetString("oidc-session-key"),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	logger.Info("OIDC authentication enabled",
+		zap.String("issuer", viper.GetString("oidc-issuer")),
+		zap.Bool("require_auth", viper.GetBool("require-auth")),
+	)
+
+	sessionKey := viper.GetString("oidc-session-key")
+	if sessionKey != "" && len(sessionKey) != 128 {
+		// NewCookieCodec silently falls back to random per-instance keys
+		// for any other length, which breaks sessions across instances
+		// and restarts — surface the misconfiguration loudly. The
+		// 128-characters-but-not-hex case is rejected by validateFlags.
+		logger.Warn("--oidc-session-key is set but not 128 hex characters; falling back to random per-instance session keys — sessions will not survive restarts or work across multiple instances (generate with: openssl rand -hex 64)",
+			zap.Int("length", len(sessionKey)))
+	}
+	return provider, server.NewCookieCodec(sessionKey), nil
+}
+
+// resolveAPITokens parses --api-token and enforces that tokens are only
+// used together with --require-auth.
+func resolveAPITokens() ([]server.APIToken, error) {
+	tokens, err := server.ParseAPITokens(getStringSliceCSV("api-token"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid --api-token: %w", err)
+	}
+	if len(tokens) > 0 && !viper.GetBool("require-auth") {
+		return nil, errors.New("--api-token is set but --require-auth is not — API tokens only apply when creation requires authentication")
+	}
+	return tokens, nil
+}
+
+// setupAuditLogger builds the audit logger, or the no-op implementation when
+// --audit-log is not set. The license requirement is checked by validateFlags.
+func setupAuditLogger(logger *zap.Logger) (server.AuditLogger, error) {
+	if !viper.GetBool("audit-log") {
+		return server.NewNoopAuditLogger(), nil
+	}
+	auditLogger, err := server.NewAuditLogger(viper.GetString("audit-log-file"))
+	if err != nil {
+		return nil, err
+	}
+	output := viper.GetString("audit-log-file")
+	if output == "" {
+		output = "stdout"
+	}
+	logger.Info("audit logging enabled", zap.String("output", output))
+	return auditLogger, nil
+}
+
+// setupWebhooks builds the webhook notifier when --webhook-url is set. The
+// license requirement and the secret-without-url case are checked by
+// validateFlags.
+func setupWebhooks(logger *zap.Logger, registry *prometheus.Registry) (*server.WebhookNotifier, error) {
+	webhookURL := viper.GetString("webhook-url")
+	if webhookURL == "" {
+		return nil, nil
+	}
+	webhooks, err := server.NewWebhookNotifier(server.WebhookConfig{
+		URL:    webhookURL,
+		Secret: viper.GetString("webhook-secret"),
+	}, logger, registry)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("webhook notifications enabled",
+		zap.String("url", webhookURL),
+		zap.Bool("signed", viper.GetString("webhook-secret") != ""),
+	)
+	return webhooks, nil
+}
+
+// resolveMaxFileSize parses --max-file-size and applies the 1MB cap for
+// unlicensed servers.
+func resolveMaxFileSize(logger *zap.Logger, licenseValid bool) (int64, error) {
+	maxFileSize, err := server.ParseSize(viper.GetString("max-file-size"))
+	if err != nil {
+		return 0, fmt.Errorf("invalid --max-file-size value %q: %w", viper.GetString("max-file-size"), err)
+	}
+	const maxFileSizeCap int64 = 1 * 1024 * 1024 // 1MB
+	if !licenseValid && maxFileSize > maxFileSizeCap {
+		logger.Warn("--max-file-size exceeds 1MB cap, capping to 1MB (a valid license removes this limit)",
+			zap.String("requested", viper.GetString("max-file-size")))
+		maxFileSize = maxFileSizeCap
+	}
+	return maxFileSize, nil
 }
 
 // listenAndServe starts a HTTP server on the given addr. It uses TLS if both

--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -190,7 +190,7 @@ func main() {
 	licenseStatus := setupLicense(logger, registry)
 
 	if err := validateFlags(licenseStatus.Valid); err != nil {
-		logger.Fatal(err.Error())
+		logger.Fatal(err.Error(), zap.Error(err))
 	}
 
 	oidcProvider, cookieCodec, err := setupOIDC(logger, licenseStatus.Valid)
@@ -200,7 +200,7 @@ func main() {
 
 	apiTokens, err := resolveAPITokens()
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Fatal(err.Error(), zap.Error(err))
 	}
 	if len(apiTokens) > 0 {
 		names := make([]string, len(apiTokens))
@@ -222,7 +222,7 @@ func main() {
 
 	maxFileSize, err := resolveMaxFileSize(logger, licenseStatus.Valid)
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Fatal(err.Error(), zap.Error(err))
 	}
 
 	db, err := setupDatabase(logger)

--- a/cmd/yopass-server/startup_test.go
+++ b/cmd/yopass-server/startup_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap/zaptest"
+)
+
+// setFlag overrides a viper key for the duration of the test, restoring the
+// previous value afterwards so tests stay independent of execution order.
+func setFlag(t *testing.T, key string, value interface{}) {
+	t.Helper()
+	prev := viper.Get(key)
+	viper.Set(key, value)
+	t.Cleanup(func() { viper.Set(key, prev) })
+}
+
+// A syntactically valid 128-hex-character session key (64 bytes).
+var validSessionKey = strings.Repeat("0123456789abcdef", 8)
+
+func TestValidateFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		flags        map[string]interface{}
+		licenseValid bool
+		wantErr      string // substring; empty means no error
+	}{
+		{
+			name: "defaults are valid",
+		},
+		{
+			name:    "invalid default-expiry",
+			flags:   map[string]interface{}{"default-expiry": "2h"},
+			wantErr: "--default-expiry",
+		},
+		{
+			name:    "invalid force-expiration",
+			flags:   map[string]interface{}{"force-expiration": "30m"},
+			wantErr: "--force-expiration",
+		},
+		{
+			name:  "valid force-expiration",
+			flags: map[string]interface{}{"force-expiration": "1d"},
+		},
+		{
+			name:    "reserved theme name",
+			flags:   map[string]interface{}{"theme-light": "custom-light"},
+			wantErr: "reserved name",
+		},
+		{
+			name:    "custom theme invalid JSON",
+			flags:   map[string]interface{}{"theme-custom-light": "{not json"},
+			wantErr: "invalid JSON for --theme-custom-light",
+		},
+		{
+			name:    "custom theme non-color variable",
+			flags:   map[string]interface{}{"theme-custom-dark": `{"--font-size":"12px"}`},
+			wantErr: "must start with --color-",
+		},
+		{
+			name:  "custom theme valid",
+			flags: map[string]interface{}{"theme-custom-dark": `{"--color-primary":"red"}`},
+		},
+		{
+			name:    "oidc-issuer requires license",
+			flags:   map[string]interface{}{"oidc-issuer": "https://accounts.example.com"},
+			wantErr: "--oidc-issuer is configured but no valid license key",
+		},
+		{
+			name:         "oidc-issuer with license",
+			flags:        map[string]interface{}{"oidc-issuer": "https://accounts.example.com"},
+			licenseValid: true,
+		},
+		{
+			name:         "require-auth without oidc-issuer",
+			flags:        map[string]interface{}{"require-auth": true},
+			licenseValid: true,
+			wantErr:      "--require-auth is set but OIDC is not configured",
+		},
+		{
+			name: "require-auth without license",
+			flags: map[string]interface{}{
+				"require-auth": true,
+				"oidc-issuer":  "https://accounts.example.com",
+			},
+			wantErr: "no valid license key",
+		},
+		{
+			name: "session key 128 chars but not hex",
+			flags: map[string]interface{}{
+				"oidc-session-key": strings.Repeat("zz", 64),
+			},
+			wantErr: "--oidc-session-key is 128 characters but not valid hex",
+		},
+		{
+			name: "session key valid hex",
+			flags: map[string]interface{}{
+				"oidc-session-key": validSessionKey,
+			},
+		},
+		{
+			name: "session key short is accepted (warned about at startup)",
+			flags: map[string]interface{}{
+				"oidc-session-key": "tooshort",
+			},
+		},
+		{
+			name:    "audit-log requires license",
+			flags:   map[string]interface{}{"audit-log": true},
+			wantErr: "--audit-log requires a valid license key",
+		},
+		{
+			name:         "audit-log with license",
+			flags:        map[string]interface{}{"audit-log": true},
+			licenseValid: true,
+		},
+		{
+			name:    "webhook-url requires license",
+			flags:   map[string]interface{}{"webhook-url": "https://hooks.example.com"},
+			wantErr: "--webhook-url requires a valid license key",
+		},
+		{
+			name:    "webhook-secret without webhook-url",
+			flags:   map[string]interface{}{"webhook-secret": "hmac-key"},
+			wantErr: "--webhook-secret is set but --webhook-url is not",
+		},
+		{
+			name: "webhook fully configured",
+			flags: map[string]interface{}{
+				"webhook-url":    "https://hooks.example.com",
+				"webhook-secret": "hmac-key",
+			},
+			licenseValid: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.flags {
+				setFlag(t, k, v)
+			}
+			err := validateFlags(tc.licenseValid)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %q", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestResolveAPITokens(t *testing.T) {
+	t.Run("no tokens", func(t *testing.T) {
+		tokens, err := resolveAPITokens()
+		if err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
+		if len(tokens) != 0 {
+			t.Fatalf("expected no tokens, got %d", len(tokens))
+		}
+	})
+
+	t.Run("token without require-auth", func(t *testing.T) {
+		setFlag(t, "api-token", []string{"ci:0123456789abcdef"})
+		_, err := resolveAPITokens()
+		if err == nil || !strings.Contains(err.Error(), "--require-auth") {
+			t.Fatalf("expected require-auth interlock error, got %v", err)
+		}
+	})
+
+	t.Run("token with require-auth", func(t *testing.T) {
+		setFlag(t, "api-token", []string{"ci:0123456789abcdef"})
+		setFlag(t, "require-auth", true)
+		tokens, err := resolveAPITokens()
+		if err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
+		if len(tokens) != 1 || tokens[0].Name != "ci" {
+			t.Fatalf("expected one token named ci, got %+v", tokens)
+		}
+	})
+
+	t.Run("malformed token", func(t *testing.T) {
+		setFlag(t, "api-token", []string{"missing-separator"})
+		setFlag(t, "require-auth", true)
+		_, err := resolveAPITokens()
+		if err == nil || !strings.Contains(err.Error(), "invalid --api-token") {
+			t.Fatalf("expected parse error, got %v", err)
+		}
+	})
+}
+
+func TestResolveMaxFileSize(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	t.Run("invalid value", func(t *testing.T) {
+		setFlag(t, "max-file-size", "not-a-size")
+		if _, err := resolveMaxFileSize(logger, false); err == nil {
+			t.Fatal("expected error for invalid size")
+		}
+	})
+
+	t.Run("unlicensed within cap", func(t *testing.T) {
+		setFlag(t, "max-file-size", "512KB")
+		size, err := resolveMaxFileSize(logger, false)
+		if err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
+		if size != 512*1024 {
+			t.Fatalf("expected 512KB, got %d", size)
+		}
+	})
+
+	t.Run("unlicensed capped at 1MB", func(t *testing.T) {
+		setFlag(t, "max-file-size", "5MB")
+		size, err := resolveMaxFileSize(logger, false)
+		if err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
+		if size != 1024*1024 {
+			t.Fatalf("expected 1MB cap, got %d", size)
+		}
+	})
+
+	t.Run("licensed uncapped", func(t *testing.T) {
+		setFlag(t, "max-file-size", "5MB")
+		size, err := resolveMaxFileSize(logger, true)
+		if err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
+		if size != 5*1024*1024 {
+			t.Fatalf("expected 5MB, got %d", size)
+		}
+	})
+}

--- a/website/src/features/display-secret/Prefetcher.tsx
+++ b/website/src/features/display-secret/Prefetcher.tsx
@@ -1,4 +1,4 @@
-import { backendDomain, crossOriginCredentials } from '@shared/lib/api';
+import { getSecret, getSecretStatus } from '@shared/lib/api';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ErrorPage from './ErrorPage';
@@ -19,31 +19,26 @@ export default function Prefetcher() {
   const [fetchRequested, setFetchRequested] = useState(!PREFETCH_SECRET);
   const [requiresAuth, setRequiresAuth] = useState(false);
 
-  const statusBaseUrl = `${backendDomain}/${isFile ? 'file' : 'secret'}/${key}`;
-  const secretUrl = `${backendDomain}/secret/${key}`;
   const oneTime = useAsync(async () => {
     if (!(PREFETCH_SECRET && !fetchRequested)) {
       return undefined;
     }
-    const statusUrl = `${statusBaseUrl}/status`;
-    const request = await fetch(statusUrl, {
-      ...crossOriginCredentials(OIDC_ENABLED),
-    });
-    if (request.status === 404) {
+    const { data, status, message } = await getSecretStatus(
+      key ?? '',
+      isFile,
+      OIDC_ENABLED,
+    );
+    if (status === 404) {
       throw new Error('Secret not found');
     }
-    if (!request.ok) {
-      throw new Error('Failed to check status');
+    if (!data) {
+      throw new Error(message ?? 'Failed to check status');
     }
-    const json = (await request.json()) as {
-      oneTime: boolean;
-      requireAuth: boolean;
-    };
-    if (json.requireAuth && !isAuthenticated) {
+    if (data.requireAuth && !isAuthenticated) {
       setRequiresAuth(true);
     }
-    return json.oneTime;
-  }, [PREFETCH_SECRET, fetchRequested, statusBaseUrl, isAuthenticated]);
+    return data.oneTime;
+  }, [PREFETCH_SECRET, fetchRequested, key, isFile, isAuthenticated]);
 
   // Auto-fetch for non one-time secrets
   const fetchSecret =
@@ -68,28 +63,22 @@ export default function Prefetcher() {
     setSecretError(null);
     (async () => {
       try {
-        const request = await fetch(secretUrl, {
-          ...crossOriginCredentials(OIDC_ENABLED),
-        });
-        if (request.status === 401) {
+        const { data, status } = await getSecret(key ?? '', OIDC_ENABLED);
+        if (status === 401) {
           setRequiresAuth(true);
           return;
         }
-        if (!request.ok) {
+        if (!data || typeof data.message !== 'string') {
           throw new Error('Failed to fetch secret');
         }
-        const json = await request.json();
-        if (!json || typeof json.message !== 'string') {
-          throw new Error('Invalid secret response');
-        }
-        setSecretValue(json.message as string);
+        setSecretValue(data.message);
       } catch (e) {
         setSecretError(e as Error);
       } finally {
         setSecretLoading(false);
       }
     })();
-  }, [isFile, fetchSecret, secretUrl, OIDC_ENABLED]);
+  }, [isFile, fetchSecret, key, OIDC_ENABLED]);
 
   // Wait for auth state to resolve before deciding whether to gate access
   if (authLoading) {

--- a/website/src/features/request-secret/ConfirmActionModal.tsx
+++ b/website/src/features/request-secret/ConfirmActionModal.tsx
@@ -1,11 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
 export type ConfirmActionType =
-  | 'revoke'
-  | 'rotate'
-  | 'remove'
-  | 'clearCollected'
-  | 'purgeAll';
+  'revoke' | 'rotate' | 'remove' | 'clearCollected' | 'purgeAll';
 
 interface ConfirmActionModalProps {
   type: ConfirmActionType;

--- a/website/src/features/request-secret/types.ts
+++ b/website/src/features/request-secret/types.ts
@@ -1,7 +1,2 @@
 export type RequestStatus =
-  | 'loading'
-  | 'pending'
-  | 'fulfilled'
-  | 'expired'
-  | 'revoked'
-  | 'collected';
+  'loading' | 'pending' | 'fulfilled' | 'expired' | 'revoked' | 'collected';

--- a/website/src/shared/lib/api.ts
+++ b/website/src/shared/lib/api.ts
@@ -60,6 +60,32 @@ export async function postSecret(
   return post(backendDomain + '/create/secret', body, oidcEnabled);
 }
 
+export interface SecretStatus {
+  oneTime: boolean;
+  requireAuth: boolean;
+}
+
+// Non-destructive status check used by the prefetch flow. isFile selects the
+// /file namespace used by streaming uploads.
+export async function getSecretStatus(
+  id: string,
+  isFile: boolean,
+  oidcEnabled: boolean,
+) {
+  return jsonFetch<SecretStatus>(
+    `${backendDomain}/${isFile ? 'file' : 'secret'}/${id}/status`,
+    { method: 'GET', ...crossOriginCredentials(oidcEnabled) },
+  );
+}
+
+// Fetches (and for one-time secrets, consumes) an encrypted text secret.
+export async function getSecret(id: string, oidcEnabled: boolean) {
+  return jsonFetch<{ message: string }>(`${backendDomain}/secret/${id}`, {
+    method: 'GET',
+    ...crossOriginCredentials(oidcEnabled),
+  });
+}
+
 // --- Read receipts (business feature) ---
 
 const receiptTokenHeader = 'X-Yopass-Receipt-Token';


### PR DESCRIPTION
Stacked on #3665 — retarget to master (or rebase) once that merges.

## yopass-server startup split

`main()` interleaved ~180 lines of flag validation, cross-flag interlocks and dependency construction, all terminating via `logger.Fatal` and none of it unit-testable. Now:

- `validateFlags` holds every pure flag check and interlock (expiry values, theme names and custom-theme JSON, OIDC/license requirements, api-token and webhook interlocks, session-key hex check) and returns an error instead of exiting
- `setupLicense`, `setupOIDC`, `setupAuditLogger`, `setupWebhooks` construct dependencies and return errors; `main()` decides to `Fatal`
- `resolveAPITokens`, `resolveMaxFileSize` handle parsing plus their interlocks

Fatal messages keep their wording. Validation now runs as one block after license verification, so a configuration broken in several ways may report a different problem first than before. `startup_test.go` covers every interlock — previously none had tests.

## Frontend

`Prefetcher` was the last JSON consumer using raw `fetch` with ad-hoc error handling; it now uses new `getSecretStatus`/`getSecret` wrappers in `api.ts` so credential handling and error shaping live in one place. `StreamingDecryptor` deliberately keeps raw `fetch` — it consumes the response body as a stream.

Also anchors the `yopass-server` `.gitignore` pattern to the repo root; the unanchored form matched the `cmd/yopass-server` source directory, so adding new files there required `git add -f`.

## Verification

- `go vet ./...` clean; full Go suite passes; `cmd/yopass-server` tests pass with `-shuffle=on -count=2`
- eslint, prettier, `tsc -b && vite build` pass
- full Playwright chromium suite: 132 passed