### PR TITLE
Add shared icons module for duplicated inline SVGs

### DIFF
--- a/website/src/features/display-secret/Decryptor.tsx
+++ b/website/src/features/display-secret/Decryptor.tsx
@@ -7,6 +7,12 @@ import { decryptMessage } from '@shared/lib/crypto';
 import { downloadBlob } from '@shared/lib/download';
 import { useCopy } from '@shared/hooks/useCopy';
 import DecryptingSpinner from '@shared/components/DecryptingSpinner';
+import {
+  CopyIcon,
+  DownloadIcon,
+  QrCodeIcon,
+  UnlockIcon,
+} from '@shared/components/icons';
 import EnterDecryptionKey from './EnterDecryptionKey';
 import FileDownloadedCard from './FileDownloadedCard';
 
@@ -91,20 +97,7 @@ export default function Decryptor({ secret }: { secret: string }) {
           }
           aria-label={t('secret.buttonDownloadFile')}
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-            className="h-6 w-6"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"
-            />
-          </svg>
+          <DownloadIcon className="h-6 w-6" />
           {t('secret.buttonDownloadFile')}
         </button>
       </>
@@ -114,20 +107,7 @@ export default function Decryptor({ secret }: { secret: string }) {
   return (
     <>
       <div className="flex items-center mb-2">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-          className="h-8 w-8 text-success mr-2"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
-          />
-        </svg>
+        <UnlockIcon className="h-8 w-8 text-success mr-2" />
         <h2 className="text-3xl font-bold">{t('secret.titleMessage')}</h2>
       </div>
       <p className="mb-6 text-base-content/70">{t('secret.subtitleMessage')}</p>
@@ -140,20 +120,7 @@ export default function Decryptor({ secret }: { secret: string }) {
           onClick={handleCopy}
           aria-label={t('secret.buttonCopyToClipboard')}
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-            className="h-5 w-5"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M8.25 7.5V6.108c0-1.135.845-2.098 1.976-2.192.373-.03.748-.057 1.123-.08M15.75 18H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08M15.75 18.75v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5A3.375 3.375 0 0 0 6.375 7.5H5.25m11.9-3.664A2.251 2.251 0 0 0 15 2.25h-1.5a2.251 2.251 0 0 0-2.15 1.586m5.8 0c.065.21.1.433.1.664v.75h-6V4.5c0-.231.035-.454.1-.664M6.75 7.5H4.875c-.621 0-1.125.504-1.125 1.125v12c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V16.5a9 9 0 0 0-9-9Z"
-            />
-          </svg>
+          <CopyIcon className="h-5 w-5" />
           {isCopied()
             ? t('secret.buttonCopied')
             : t('secret.buttonCopyToClipboard')}
@@ -170,20 +137,7 @@ export default function Decryptor({ secret }: { secret: string }) {
                 : t('secret.showQrCode')
             }
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="h-5 w-5"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 3.75 9.375v-4.5ZM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 0 1-1.125-1.125v-4.5ZM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 13.5 9.375v-4.5Z"
-              />
-            </svg>
+            <QrCodeIcon className="h-5 w-5" />
             {showQR && !tooLongForQRCode
               ? t('secret.hideQrCode')
               : t('secret.showQrCode')}

--- a/website/src/features/display-secret/EnterDecryptionKey.tsx
+++ b/website/src/features/display-secret/EnterDecryptionKey.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ErrorCircleIcon, KeyIcon, UnlockIcon } from '@shared/components/icons';
 
 export default function EnterDecryptionKey({
   setPassword,
@@ -22,20 +23,7 @@ export default function EnterDecryptionKey({
   return (
     <div className="max-w-full mt-6">
       <div className="flex items-center mb-4">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-          className="h-8 w-8 text-primary mr-3"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z"
-          />
-        </svg>
+        <KeyIcon className="h-8 w-8 text-primary mr-3" />
         <h2 className="text-3xl font-bold">
           {t('display.titleDecryptionKey')}
         </h2>
@@ -47,18 +35,7 @@ export default function EnterDecryptionKey({
 
       {errorMessage && (
         <div className="alert alert-error mb-6 shadow-sm">
-          <svg
-            className="w-6 h-6 stroke-current shrink-0"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
+          <ErrorCircleIcon className="w-6 h-6 shrink-0" />
           <div>
             <div className="font-semibold text-base">
               {t('display.errorInvalidPasswordDetailed')}
@@ -86,20 +63,7 @@ export default function EnterDecryptionKey({
             type="submit"
             className="btn btn-primary px-12 py-4 h-12 text-base font-semibold rounded-lg transition-all duration-200 max-w-md w-full"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="h-6 w-6 mr-2"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
-              />
-            </svg>
+            <UnlockIcon className="h-6 w-6 mr-2" />
             {t('display.buttonDecryptSecret')}
           </button>
         </div>

--- a/website/src/features/display-secret/ErrorPage.tsx
+++ b/website/src/features/display-secret/ErrorPage.tsx
@@ -1,24 +1,17 @@
 import { useTranslation } from 'react-i18next';
+import {
+  ClockIcon,
+  EyeIcon,
+  LinkIcon,
+  WarningIcon,
+} from '@shared/components/icons';
 
 export default function ErrorPage() {
   const { t } = useTranslation();
   return (
     <div className="max-w-2xl mx-auto">
       <div className="flex items-center mb-6">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-          className="h-8 w-8 text-error mr-3"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
-          />
-        </svg>
+        <WarningIcon className="h-8 w-8 text-error mr-3" />
         <h2 className="text-3xl font-bold text-error">{t('error.title')}</h2>
       </div>
 
@@ -27,25 +20,7 @@ export default function ErrorPage() {
       <div className="space-y-6">
         <div className="p-5 bg-base-100 border border-base-300 rounded-lg">
           <div className="flex items-center mb-3">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="h-6 w-6 text-warning mr-3"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-              />
-            </svg>
+            <EyeIcon className="h-6 w-6 text-warning mr-3" />
             <span className="font-semibold text-lg text-base-content">
               {t('error.titleOpened')}
             </span>
@@ -59,20 +34,7 @@ export default function ErrorPage() {
 
         <div className="p-5 bg-base-100 border border-base-300 rounded-lg">
           <div className="flex items-center mb-3">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="h-6 w-6 text-warning mr-3"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"
-              />
-            </svg>
+            <LinkIcon className="h-6 w-6 text-warning mr-3" />
             <span className="font-semibold text-lg text-base-content">
               {t('error.titleBrokenLink')}
             </span>
@@ -84,20 +46,7 @@ export default function ErrorPage() {
 
         <div className="p-5 bg-base-100 border border-base-300 rounded-lg">
           <div className="flex items-center mb-3">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="h-6 w-6 text-warning mr-3"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-              />
-            </svg>
+            <ClockIcon className="h-6 w-6 text-warning mr-3" />
             <span className="font-semibold text-lg text-base-content">
               {t('error.titleExpired')}
             </span>

--- a/website/src/features/display-secret/FileDownloadedCard.tsx
+++ b/website/src/features/display-secret/FileDownloadedCard.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { FileDownloadIcon, FileListIcon } from '@shared/components/icons';
 
 // Success view shown after a file secret has been decrypted and downloaded:
 // title, subtitle and a card naming the file. children render inside the
@@ -15,40 +16,14 @@ export default function FileDownloadedCard({
   return (
     <>
       <div className="flex items-center mb-2">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-          className="h-8 w-8 text-success mr-2"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z"
-          />
-        </svg>
+        <FileListIcon className="h-8 w-8 text-success mr-2" />
         <h2 className="text-3xl font-bold">{t('secret.titleFile')}</h2>
       </div>
       <p className="mb-6 text-base-content/70">{t('secret.subtitleFile')}</p>
       <div className="mb-6">
         <div className="bg-base-200 border border-base-300 rounded-xl p-6">
           <div className="flex items-center">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="h-6 w-6 mr-2"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M9 8.25H7.5a2.25 2.25 0 0 0-2.25 2.25v9a2.25 2.25 0 0 0 2.25 2.25h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25H15M9 12l3 3m0 0 3-3m-3 3V2.25"
-              />
-            </svg>
+            <FileDownloadIcon className="h-6 w-6 mr-2" />
             <span className="text-lg">
               {t('secret.fileDownloaded')}: <strong>{filename}</strong>
             </span>

--- a/website/src/features/display-secret/ReceiptStatus.tsx
+++ b/website/src/features/display-secret/ReceiptStatus.tsx
@@ -5,6 +5,7 @@ import type { ReceiptStatus as ReceiptStatusData } from '@shared/lib/api';
 import { formatDateTime } from '@shared/lib/dateFormat';
 import { useDateFormat } from '@shared/hooks/useDateFormat';
 import { recordReceiptState } from '@shared/lib/receiptStore';
+import { CheckIcon, RefreshIcon } from '@shared/components/icons';
 
 const POLL_INTERVAL_MS = 10_000;
 
@@ -64,20 +65,7 @@ export default function ReceiptStatus({ uuid, token }: ReceiptStatusProps) {
         className="inline-flex items-center gap-2 text-success font-medium"
         data-testid="receipt-status-viewed"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth="2"
-          stroke="currentColor"
-          className="size-5"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="m4.5 12.75 6 6 9-13.5"
-          />
-        </svg>
+        <CheckIcon className="size-5" />
         {t('result.receiptViewed', {
           time: formatDateTime(receipt?.viewed_at ?? 0, dateFormat),
         })}
@@ -130,20 +118,7 @@ export default function ReceiptStatus({ uuid, token }: ReceiptStatusProps) {
             onClick={refresh}
             data-testid="receipt-refresh"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth="1.5"
-              stroke="currentColor"
-              className="size-4"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
-              />
-            </svg>
+            <RefreshIcon className="size-4" />
             {t('result.receiptRefresh')}
           </button>
         )}

--- a/website/src/features/display-secret/Result.tsx
+++ b/website/src/features/display-secret/Result.tsx
@@ -1,6 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { useConfig } from '@shared/hooks/useConfig';
 import { useCopy } from '@shared/hooks/useCopy';
+import {
+  CheckCircleIcon,
+  CheckIcon,
+  CopyIcon,
+  InfoIcon,
+} from '@shared/components/icons';
 import ReceiptStatus from '@features/display-secret/ReceiptStatus';
 
 interface ResultProps {
@@ -32,35 +38,9 @@ function CopyButton({
       title={title}
     >
       {copied ? (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth="2"
-          stroke="currentColor"
-          className="size-4"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="m4.5 12.75 6 6 9-13.5"
-          />
-        </svg>
+        <CheckIcon className="size-4" />
       ) : (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth="1.5"
-          stroke="currentColor"
-          className="size-4"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M8.25 7.5V6.108c0-1.135.845-2.098 1.976-2.192.373-.03.748-.057 1.123-.08M15.75 18H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08M15.75 18.75v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5A3.375 3.375 0 0 0 6.375 7.5H5.25m11.9-3.664A2.251 2.251 0 0 0 15 2.25h-1.5a2.251 2.251 0 0 0-2.15 1.586m5.8 0c.065.21.1.433.1.664v.75h-6V4.5c0-.231.035-.454.1-.664M6.75 7.5H4.875c-.621 0-1.125.504-1.125 1.125v12c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V16.5a9 9 0 0 0-9-9Z"
-          />
-        </svg>
+        <CopyIcon className="size-4" />
       )}
       {copied ? copiedLabel : copyLabel}
     </button>
@@ -88,37 +68,13 @@ function Result({
     <>
       {' '}
       <div className="flex items-center gap-3 mb-2">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-          className="h-7 w-7 text-success"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-          />
-        </svg>
+        <CheckCircleIcon className="h-7 w-7 text-success" />
         <h2 className="text-2xl font-bold">{t('result.title')}</h2>
       </div>
       <p className="mb-6 text-base">{t('result.subtitle')}</p>
       {oneTime && (
         <div className="alert alert-warning mb-6 shadow-sm">
-          <svg
-            className="w-6 h-6 stroke-current shrink-0"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M13 16h-1v-4h-1m1-4h.01M12 20a8 8 0 100-16 8 8 0 000 16z"
-            />
-          </svg>
+          <InfoIcon className="w-6 h-6 shrink-0" />
           <div>
             <div className="font-semibold text-base mb-1">
               {t('result.reminderTitle')}

--- a/website/src/shared/components/AuthRequiredNotice.tsx
+++ b/website/src/shared/components/AuthRequiredNotice.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { backendDomain } from '@shared/lib/api';
+import { LockIcon } from '@shared/components/icons';
 
 // Shown when a secret requires authentication and the visitor has no
 // session: a lock icon, explanation and a sign-in link.
@@ -7,20 +8,7 @@ export default function AuthRequiredNotice() {
   const { t } = useTranslation();
   return (
     <div className="flex flex-col items-center text-center py-16">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        strokeWidth={1.5}
-        stroke="currentColor"
-        className="h-14 w-14 text-primary mb-4"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
-        />
-      </svg>
+      <LockIcon className="h-14 w-14 text-primary mb-4" />
       <h2 className="text-3xl font-bold mb-3">
         {t('display.authRequiredTitle')}
       </h2>

--- a/website/src/shared/components/DecryptingSpinner.tsx
+++ b/website/src/shared/components/DecryptingSpinner.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { SpinnerIcon } from '@shared/components/icons';
 
 // Full-width spinner shown while a secret or file is being decrypted.
 // progress, when non-null, renders a percentage bar below the spinner.
@@ -10,27 +11,7 @@ export default function DecryptingSpinner({
   const { t } = useTranslation();
   return (
     <div className="flex flex-col items-center justify-center py-16 text-base-content/70">
-      <svg
-        className="animate-spin h-8 w-8 text-primary"
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-      >
-        <circle
-          className="opacity-25"
-          cx="12"
-          cy="12"
-          r="10"
-          stroke="currentColor"
-          strokeWidth="4"
-        ></circle>
-        <path
-          className="opacity-75"
-          fill="currentColor"
-          d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
-        ></path>
-      </svg>
+      <SpinnerIcon className="animate-spin h-8 w-8 text-primary" />
       <p className="mt-4 text-lg font-medium">
         {t('display.decryptingMessage')}
       </p>

--- a/website/src/shared/components/icons.tsx
+++ b/website/src/shared/components/icons.tsx
@@ -1,0 +1,223 @@
+import type { ReactNode } from 'react';
+
+// Shared inline SVG icons (heroicons outline style, 24×24 viewBox,
+// stroke: currentColor). Size and color come from the className,
+// e.g. "h-6 w-6 text-success".
+
+interface IconProps {
+  className?: string;
+}
+
+function Icon({
+  className,
+  strokeWidth = 1.5,
+  children,
+}: IconProps & { strokeWidth?: number; children: ReactNode }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={strokeWidth}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  );
+}
+
+function path(d: string) {
+  return <path strokeLinecap="round" strokeLinejoin="round" d={d} />;
+}
+
+export function LockIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z',
+      )}
+    </Icon>
+  );
+}
+
+export function UnlockIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z',
+      )}
+    </Icon>
+  );
+}
+
+export function KeyIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z',
+      )}
+    </Icon>
+  );
+}
+
+export function EyeIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z',
+      )}
+      {path('M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z')}
+    </Icon>
+  );
+}
+
+export function WarningIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z',
+      )}
+    </Icon>
+  );
+}
+
+export function LinkIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244',
+      )}
+    </Icon>
+  );
+}
+
+export function ClockIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path('M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z')}
+    </Icon>
+  );
+}
+
+export function InfoIcon({ className }: IconProps) {
+  return (
+    <Icon className={className} strokeWidth={2}>
+      {path('M13 16h-1v-4h-1m1-4h.01M12 20a8 8 0 100-16 8 8 0 000 16z')}
+    </Icon>
+  );
+}
+
+export function ErrorCircleIcon({ className }: IconProps) {
+  return (
+    <Icon className={className} strokeWidth={2}>
+      {path(
+        'M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z',
+      )}
+    </Icon>
+  );
+}
+
+export function CheckIcon({ className }: IconProps) {
+  return (
+    <Icon className={className} strokeWidth={2}>
+      {path('m4.5 12.75 6 6 9-13.5')}
+    </Icon>
+  );
+}
+
+export function CheckCircleIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path('M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z')}
+    </Icon>
+  );
+}
+
+export function CopyIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M8.25 7.5V6.108c0-1.135.845-2.098 1.976-2.192.373-.03.748-.057 1.123-.08M15.75 18H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08M15.75 18.75v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5A3.375 3.375 0 0 0 6.375 7.5H5.25m11.9-3.664A2.251 2.251 0 0 0 15 2.25h-1.5a2.251 2.251 0 0 0-2.15 1.586m5.8 0c.065.21.1.433.1.664v.75h-6V4.5c0-.231.035-.454.1-.664M6.75 7.5H4.875c-.621 0-1.125.504-1.125 1.125v12c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V16.5a9 9 0 0 0-9-9Z',
+      )}
+    </Icon>
+  );
+}
+
+export function QrCodeIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 3.75 9.375v-4.5ZM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 0 1-1.125-1.125v-4.5ZM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 13.5 9.375v-4.5Z',
+      )}
+    </Icon>
+  );
+}
+
+export function DownloadIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3',
+      )}
+    </Icon>
+  );
+}
+
+export function FileDownloadIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M9 8.25H7.5a2.25 2.25 0 0 0-2.25 2.25v9a2.25 2.25 0 0 0 2.25 2.25h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25H15M9 12l3 3m0 0 3-3m-3 3V2.25',
+      )}
+    </Icon>
+  );
+}
+
+export function FileListIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z',
+      )}
+    </Icon>
+  );
+}
+
+export function RefreshIcon({ className }: IconProps) {
+  return (
+    <Icon className={className}>
+      {path(
+        'M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99',
+      )}
+    </Icon>
+  );
+}
+
+// Indeterminate spinner; pass "animate-spin" in className to animate.
+export function SpinnerIcon({ className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Inline SVG path data (lock, eye, copy, QR, download, spinner, …) is copy-pasted across many components. This adds `website/src/shared/components/icons.tsx` with one component per icon (heroicons outline style, `className` prop for size/color) and sweeps the first batch of call sites:

- `features/display-secret/`: `Decryptor`, `EnterDecryptionKey`, `ErrorPage`, `FileDownloadedCard`, `ReceiptStatus`, `Result`
- `shared/components/`: `AuthRequiredNotice`, `DecryptingSpinner`

Remaining call sites (`CreateSecret`, `StreamingUpload`, `Navbar`, `SettingsMenu`, `request-secret/*`, `receipts/*`, …) keep their inline SVGs for now and can be swept incrementally in follow-ups.

Purely mechanical apart from two deliberate micro-changes:

- icons now carry `aria-hidden="true"` (they are always decorative next to a text label)
- redundant `stroke-current` classes dropped where the icon already sets `stroke="currentColor"`

## Test plan

- `yarn lint` (eslint, prettier, locale key parity)
- `yarn build`
- `npx playwright test --project=chromium` — 132 passed
