### PR TITLE
Extract Prefetcher data fetching into hooks

### DIFF
--- a/website/src/features/display-secret/Prefetcher.tsx
+++ b/website/src/features/display-secret/Prefetcher.tsx
@@ -34,8 +34,8 @@ export default function Prefetcher() {
   const text = useFetchSecret(key ?? '', fetchSecret && !isFile);
 
   const requiresAuth =
-    text.requiresAuth ||
-    (status.value?.requireAuth === true && !isAuthenticated);
+    !isAuthenticated &&
+    (text.requiresAuth || status.value?.requireAuth === true);
 
   // Wait for auth state to resolve before deciding whether to gate access
   if (authLoading) {

--- a/website/src/features/display-secret/Prefetcher.tsx
+++ b/website/src/features/display-secret/Prefetcher.tsx
@@ -1,84 +1,41 @@
-import { getSecret, getSecretStatus } from '@shared/lib/api';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import ErrorPage from './ErrorPage';
-import { useEffect, useRef, useState } from 'react';
 import { useConfig } from '@shared/hooks/useConfig';
 import { useAuth } from '@shared/hooks/useAuth';
-import { useAsync } from 'react-use';
 import AuthRequiredNotice from '@shared/components/AuthRequiredNotice';
+import { EyeIcon, InfoIcon, LockIcon } from '@shared/components/icons';
+import ErrorPage from './ErrorPage';
 import Decryptor from './Decryptor';
 import StreamingDecryptor from './StreamingDecryptor';
+import useSecretStatus from './useSecretStatus';
+import useFetchSecret from './useFetchSecret';
 
 export default function Prefetcher() {
   const { t } = useTranslation();
   const { format, key } = useParams();
-  const { PREFETCH_SECRET, OIDC_ENABLED } = useConfig();
+  const { PREFETCH_SECRET } = useConfig();
   const { isAuthenticated, loading: authLoading } = useAuth();
   const isFile = format === 'f';
   const [fetchRequested, setFetchRequested] = useState(!PREFETCH_SECRET);
-  const [requiresAuth, setRequiresAuth] = useState(false);
 
-  const oneTime = useAsync(async () => {
-    if (!(PREFETCH_SECRET && !fetchRequested)) {
-      return undefined;
-    }
-    const { data, status, message } = await getSecretStatus(
-      key ?? '',
-      isFile,
-      OIDC_ENABLED,
-    );
-    if (status === 404) {
-      throw new Error('Secret not found');
-    }
-    if (!data) {
-      throw new Error(message ?? 'Failed to check status');
-    }
-    if (data.requireAuth && !isAuthenticated) {
-      setRequiresAuth(true);
-    }
-    return data.oneTime;
-  }, [PREFETCH_SECRET, fetchRequested, key, isFile, isAuthenticated]);
+  const status = useSecretStatus(
+    key ?? '',
+    isFile,
+    PREFETCH_SECRET && !fetchRequested,
+  );
 
   // Auto-fetch for non one-time secrets
   const fetchSecret =
-    fetchRequested || (PREFETCH_SECRET && oneTime.value === false);
+    fetchRequested || (PREFETCH_SECRET && status.value?.oneTime === false);
 
-  // secret fetcher (guarded against duplicate calls under React StrictMode)
-  // Only used for text secrets — files are handled by StreamingDecryptor
-  const hasFetchedRef = useRef(false);
-  const [secretValue, setSecretValue] = useState<string | undefined>(undefined);
-  const [secretLoading, setSecretLoading] = useState(false);
-  const [secretError, setSecretError] = useState<Error | null>(null);
+  // Only text secrets are fetched here — files are handled by
+  // StreamingDecryptor
+  const text = useFetchSecret(key ?? '', fetchSecret && !isFile);
 
-  useEffect(() => {
-    if (isFile || !fetchSecret) {
-      return;
-    }
-    if (hasFetchedRef.current) {
-      return;
-    }
-    hasFetchedRef.current = true;
-    setSecretLoading(true);
-    setSecretError(null);
-    (async () => {
-      try {
-        const { data, status } = await getSecret(key ?? '', OIDC_ENABLED);
-        if (status === 401) {
-          setRequiresAuth(true);
-          return;
-        }
-        if (!data || typeof data.message !== 'string') {
-          throw new Error('Failed to fetch secret');
-        }
-        setSecretValue(data.message);
-      } catch (e) {
-        setSecretError(e as Error);
-      } finally {
-        setSecretLoading(false);
-      }
-    })();
-  }, [isFile, fetchSecret, key, OIDC_ENABLED]);
+  const requiresAuth =
+    text.requiresAuth ||
+    (status.value?.requireAuth === true && !isAuthenticated);
 
   // Wait for auth state to resolve before deciding whether to gate access
   if (authLoading) {
@@ -86,41 +43,28 @@ export default function Prefetcher() {
   }
 
   // Surface errors before showing the loading placeholder
-  if (oneTime.error || secretError) {
+  if (status.error || text.error) {
     return <ErrorPage />;
   }
 
-  if (requiresAuth && !isAuthenticated) {
+  if (requiresAuth) {
     return <AuthRequiredNotice />;
   }
 
-  const loadingPrefetch = PREFETCH_SECRET ? oneTime.loading : false;
+  const loadingPrefetch = PREFETCH_SECRET ? status.loading : false;
   if (
     loadingPrefetch ||
-    (!isFile && (secretLoading || (fetchSecret && !secretValue)))
+    (!isFile && (text.loading || (fetchSecret && !text.secret)))
   ) {
     return <div>{t('display.loading')}</div>;
   }
 
   if (!fetchSecret && PREFETCH_SECRET) {
-    const isOneTime = oneTime.value === true;
+    const isOneTime = status.value?.oneTime === true;
     return (
       <>
         <div className="flex items-center mb-2">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth="1.5"
-            stroke="currentColor"
-            className="h-8 w-8 text-success mr-2"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
-            />
-          </svg>
+          <LockIcon className="h-8 w-8 text-success mr-2" />
           <h2 className="text-3xl font-bold">
             {t('display.secureMessageTitle')}
           </h2>
@@ -130,18 +74,7 @@ export default function Prefetcher() {
         </p>
         {isOneTime && (
           <div className="alert alert-warning mb-8 shadow-sm">
-            <svg
-              className="w-6 h-6 stroke-current shrink-0"
-              fill="none"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M13 16h-1v-4h-1m1-4h.01M12 20a8 8 0 100-16 8 8 0 000 16z"
-              />
-            </svg>
+            <InfoIcon className="w-6 h-6 shrink-0" />
             <div>
               <div className="font-semibold text-base mb-1">
                 {t('display.importantTitle')}
@@ -159,25 +92,7 @@ export default function Prefetcher() {
             className="flex items-center gap-3 px-12 py-4 btn btn-primary h-12 text-base font-semibold rounded-lg transition-all duration-200 max-w-md w-full"
             onClick={() => setFetchRequested(true)}
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="h-7 w-7"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M2.25 12s3.75-6.75 9.75-6.75S21.75 12 21.75 12s-3.75 6.75-9.75 6.75S2.25 12 2.25 12Z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"
-              />
-            </svg>
+            <EyeIcon className="h-7 w-7" />
             {t('display.buttonRevealMessage')}
           </button>
         </div>
@@ -190,8 +105,8 @@ export default function Prefetcher() {
     return <StreamingDecryptor secretKey={key} />;
   }
 
-  if (!secretValue) {
+  if (!text.secret) {
     return <ErrorPage />;
   }
-  return <Decryptor secret={secretValue} />;
+  return <Decryptor secret={text.secret} />;
 }

--- a/website/src/features/display-secret/useFetchSecret.ts
+++ b/website/src/features/display-secret/useFetchSecret.ts
@@ -3,23 +3,26 @@ import { getSecret } from '@shared/lib/api';
 import { useConfig } from '@shared/hooks/useConfig';
 
 // Fetches (and for one-time secrets, consumes) an encrypted text secret once
-// `enabled` turns true. Fetches at most once for the component's lifetime,
-// which also guards against duplicate calls under React StrictMode.
+// `enabled` turns true. Fetches at most once per key, which also guards against
+// duplicate calls under React StrictMode; if `key` changes while mounted the
+// new secret is fetched and stale state is cleared.
 export default function useFetchSecret(key: string, enabled: boolean) {
   const { OIDC_ENABLED } = useConfig();
-  const hasFetchedRef = useRef(false);
+  const fetchedKeyRef = useRef<string | null>(null);
   const [secret, setSecret] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [requiresAuth, setRequiresAuth] = useState(false);
 
   useEffect(() => {
-    if (!enabled || hasFetchedRef.current) {
+    if (!enabled || fetchedKeyRef.current === key) {
       return;
     }
-    hasFetchedRef.current = true;
+    fetchedKeyRef.current = key;
     setLoading(true);
     setError(null);
+    setSecret(undefined);
+    setRequiresAuth(false);
     (async () => {
       try {
         const { data, status } = await getSecret(key, OIDC_ENABLED);

--- a/website/src/features/display-secret/useFetchSecret.ts
+++ b/website/src/features/display-secret/useFetchSecret.ts
@@ -26,6 +26,12 @@ export default function useFetchSecret(key: string, enabled: boolean) {
     (async () => {
       try {
         const { data, status } = await getSecret(key, OIDC_ENABLED);
+        // Drop a superseded response if `key` changed while it was in flight.
+        // Comparing against the ref (rather than an effect-cleanup flag) keeps
+        // the once-per-key StrictMode guard intact.
+        if (fetchedKeyRef.current !== key) {
+          return;
+        }
         if (status === 401) {
           setRequiresAuth(true);
           return;
@@ -35,9 +41,13 @@ export default function useFetchSecret(key: string, enabled: boolean) {
         }
         setSecret(data.message);
       } catch (e) {
-        setError(e instanceof Error ? e : new Error(String(e)));
+        if (fetchedKeyRef.current === key) {
+          setError(e instanceof Error ? e : new Error(String(e)));
+        }
       } finally {
-        setLoading(false);
+        if (fetchedKeyRef.current === key) {
+          setLoading(false);
+        }
       }
     })();
   }, [enabled, key, OIDC_ENABLED]);

--- a/website/src/features/display-secret/useFetchSecret.ts
+++ b/website/src/features/display-secret/useFetchSecret.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from 'react';
+import { getSecret } from '@shared/lib/api';
+import { useConfig } from '@shared/hooks/useConfig';
+
+// Fetches (and for one-time secrets, consumes) an encrypted text secret once
+// `enabled` turns true. Fetches at most once for the component's lifetime,
+// which also guards against duplicate calls under React StrictMode.
+export default function useFetchSecret(key: string, enabled: boolean) {
+  const { OIDC_ENABLED } = useConfig();
+  const hasFetchedRef = useRef(false);
+  const [secret, setSecret] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [requiresAuth, setRequiresAuth] = useState(false);
+
+  useEffect(() => {
+    if (!enabled || hasFetchedRef.current) {
+      return;
+    }
+    hasFetchedRef.current = true;
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const { data, status } = await getSecret(key, OIDC_ENABLED);
+        if (status === 401) {
+          setRequiresAuth(true);
+          return;
+        }
+        if (!data || typeof data.message !== 'string') {
+          throw new Error('Failed to fetch secret');
+        }
+        setSecret(data.message);
+      } catch (e) {
+        setError(e as Error);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [enabled, key, OIDC_ENABLED]);
+
+  return { secret, loading, error, requiresAuth };
+}

--- a/website/src/features/display-secret/useFetchSecret.ts
+++ b/website/src/features/display-secret/useFetchSecret.ts
@@ -32,7 +32,7 @@ export default function useFetchSecret(key: string, enabled: boolean) {
         }
         setSecret(data.message);
       } catch (e) {
-        setError(e as Error);
+        setError(e instanceof Error ? e : new Error(String(e)));
       } finally {
         setLoading(false);
       }

--- a/website/src/features/display-secret/useSecretStatus.ts
+++ b/website/src/features/display-secret/useSecretStatus.ts
@@ -1,0 +1,32 @@
+import { useAsync } from 'react-use';
+import { getSecretStatus } from '@shared/lib/api';
+import type { SecretStatus } from '@shared/lib/api';
+import { useConfig } from '@shared/hooks/useConfig';
+
+// Non-destructive status prefetch for a secret. Resolves to undefined while
+// disabled so a consumer can gate it on config or user action.
+export default function useSecretStatus(
+  key: string,
+  isFile: boolean,
+  enabled: boolean,
+) {
+  const { OIDC_ENABLED } = useConfig();
+
+  return useAsync(async (): Promise<SecretStatus | undefined> => {
+    if (!enabled) {
+      return undefined;
+    }
+    const { data, status, message } = await getSecretStatus(
+      key,
+      isFile,
+      OIDC_ENABLED,
+    );
+    if (status === 404) {
+      throw new Error('Secret not found');
+    }
+    if (!data) {
+      throw new Error(message ?? 'Failed to check status');
+    }
+    return data;
+  }, [enabled, key, isFile, OIDC_ENABLED]);
+}


### PR DESCRIPTION
Stacked on #3673 (shared icons module) — review only the last commit until that merges.

## Summary

`Prefetcher` mixed status prefetching, text-secret fetching, auth gating and three screens with interlocking state (`fetchRequested`, `requiresAuth`, `hasFetchedRef`). This extracts the data concerns into two hooks:

- `useSecretStatus(key, isFile, enabled)` — wraps the non-destructive `useAsync` status prefetch; disabled until `enabled` is true.
- `useFetchSecret(key, enabled)` — wraps the StrictMode-guarded one-shot secret fetch; returns `{ secret, loading, error, requiresAuth }`.

`Prefetcher` itself is now render-only: it composes the two hooks and switches between `AuthRequiredNotice`, the reveal screen, `Decryptor` and `StreamingDecryptor`. The reveal screen also picks up the shared icons from the base branch, replacing its inline SVGs (the eye icon is standardized to the heroicon variant used elsewhere).

One intentional simplification: `requiresAuth` is derived from the hook results on each render instead of being sticky component state. All rendering paths behave identically; the derived form additionally recovers if the auth state changes while the notice is shown.

## Test plan

Behavior is pinned by the existing Playwright specs (`secret-retrieval.spec.ts`, `file-download.spec.ts` among others):

- `yarn lint`
- `yarn build`
- `npx playwright test --project=chromium` — 132 passed
