### PR TITLE
Include the secret request label in request.* webhook events

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -54,8 +54,28 @@ Each event is delivered as an HTTP `POST` with a JSON body:
 | `timestamp` | When the event occurred (UTC, RFC 3339) |
 | `secret_id` | A short SHA-256 fingerprint of the secret or request ID — the same identifier used in [audit logs](audit-logging), so events and log lines correlate directly |
 | `kind` | `secret` (text), `file` (upload), or `request` (secret request) |
+| `label` | The request's label, on `request.*` events only. Omitted when the request has none, and never present on `secret.*` events |
 | `one_time` | Whether the secret was one-time (always `false` for requests) |
 | `expiration_seconds` | The secret's or request's lifetime (`created` and `expired` events) |
+
+A `request.*` event carries the label the requester gave the request, so a receiver can name it
+without holding the request link:
+
+```json
+{
+  "event": "request.created",
+  "timestamp": "2026-06-11T13:37:00.000000042Z",
+  "secret_id": "d22b8554f618",
+  "kind": "request",
+  "label": "Database credentials for Acme",
+  "one_time": false,
+  "expiration_seconds": 3600
+}
+```
+
+The label is already public — anyone holding the request link reads it back from `GET /request/{key}` —
+so it reveals nothing the receiver could not otherwise learn. Treat it as logged: do not put sensitive
+information in a request label.
 
 **The payload never contains secret content, decryption keys, or the raw secret ID.** A compromised webhook endpoint learns that *something* was created or viewed, but gains nothing that could retrieve a secret.
 

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -204,7 +204,7 @@ func (y *Server) createSecretRequest(w http.ResponseWriter, request *http.Reques
 	}
 
 	audit.success(withExpiration(body.Expiration))
-	y.webhookRequestCreated(id, body.Expiration)
+	y.webhookRequestCreated(id, body.Label, body.Expiration)
 	y.writeJSON(w, http.StatusOK, map[string]interface{}{
 		"id":         id,
 		"token":      token,
@@ -265,10 +265,15 @@ func (y *Server) fulfillSecretRequest(w http.ResponseWriter, request *http.Reque
 		return
 	}
 
+	// The label is only reachable from inside the atomic update; capturing it
+	// here spares a second read, and it is reassigned on every attempt so a
+	// retried transaction cannot leave a stale value behind.
+	var label string
 	err := y.updateRequest(id, func(req *SecretRequest) error {
 		if req.State == RequestStateFulfilled {
 			return errAlreadyFulfilled
 		}
+		label = req.Label
 		req.State = RequestStateFulfilled
 		req.Secret = body.Message
 		return nil
@@ -290,7 +295,7 @@ func (y *Server) fulfillSecretRequest(w http.ResponseWriter, request *http.Reque
 	}
 
 	audit.success()
-	y.webhookRequestFulfilled(id)
+	y.webhookRequestFulfilled(id, label)
 	y.writeJSON(w, http.StatusOK, map[string]string{"message": "secret provided"})
 }
 

--- a/pkg/server/webhook.go
+++ b/pkg/server/webhook.go
@@ -46,12 +46,18 @@ const webhookSignatureHeader = "X-Yopass-Signature"
 // retrieval key is never sent, so a compromised webhook endpoint cannot be
 // used to fetch secrets.
 type WebhookEvent struct {
-	Event             string    `json:"event"`
-	Timestamp         time.Time `json:"timestamp"`
-	SecretID          string    `json:"secret_id"`
-	Kind              string    `json:"kind"`
-	OneTime           bool      `json:"one_time"`
-	ExpirationSeconds int32     `json:"expiration_seconds,omitempty"`
+	Event     string    `json:"event"`
+	Timestamp time.Time `json:"timestamp"`
+	SecretID  string    `json:"secret_id"`
+	Kind      string    `json:"kind"`
+	// Label is the requester supplied description of a secret request. It is
+	// already public — anyone holding the request link reads it back from
+	// GET /request/{key} — so echoing it here reveals nothing new, and it lets
+	// a receiver name a request without being able to resolve its fingerprint.
+	// Secrets carry no label, hence omitempty.
+	Label             string `json:"label,omitempty"`
+	OneTime           bool   `json:"one_time"`
+	ExpirationSeconds int32  `json:"expiration_seconds,omitempty"`
 }
 
 // WebhookConfig configures the notifier. URL is required; everything else has
@@ -100,6 +106,7 @@ type WebhookNotifier struct {
 // webhookExpiry tracks one live secret or request for the expiry watcher.
 type webhookExpiry struct {
 	kind         string
+	label        string
 	oneTime      bool
 	lifetime     int32
 	deadline     time.Time
@@ -212,10 +219,12 @@ func (n *WebhookNotifier) SecretDeleted(id string) {
 }
 
 // RequestCreated enqueues a created event for a secret request and starts
-// expiry tracking.
-func (n *WebhookNotifier) RequestCreated(id string, expiration int32) {
+// expiry tracking. The label is kept on the tracker so the later expired event
+// can carry it too: the request itself is gone by the time that fires.
+func (n *WebhookNotifier) RequestCreated(id, label string, expiration int32) {
 	n.trackExpiry(id, webhookExpiry{
 		kind:         WebhookKindRequest,
+		label:        label,
 		lifetime:     expiration,
 		expiredEvent: WebhookEventRequestExpired,
 	})
@@ -223,6 +232,7 @@ func (n *WebhookNotifier) RequestCreated(id string, expiration int32) {
 		Event:             WebhookEventRequestCreated,
 		SecretID:          redactSecretID(id),
 		Kind:              WebhookKindRequest,
+		Label:             label,
 		ExpirationSeconds: expiration,
 	})
 }
@@ -230,11 +240,12 @@ func (n *WebhookNotifier) RequestCreated(id string, expiration int32) {
 // RequestFulfilled enqueues a fulfilled event: a responder provided the
 // secret. The request stays tracked — a fulfilled request that is never
 // collected still produces a request.expired event.
-func (n *WebhookNotifier) RequestFulfilled(id string) {
+func (n *WebhookNotifier) RequestFulfilled(id, label string) {
 	n.enqueue(WebhookEvent{
 		Event:    WebhookEventRequestFulfilled,
 		SecretID: redactSecretID(id),
 		Kind:     WebhookKindRequest,
+		Label:    label,
 	})
 }
 
@@ -296,6 +307,7 @@ func (n *WebhookNotifier) expiryWatcher() {
 					Event:             exp.expiredEvent,
 					SecretID:          redactSecretID(id),
 					Kind:              exp.kind,
+					Label:             exp.label,
 					OneTime:           exp.oneTime,
 					ExpirationSeconds: exp.lifetime,
 				})
@@ -425,15 +437,15 @@ func (y *Server) webhookDeleted(id string) {
 	}
 }
 
-func (y *Server) webhookRequestCreated(id string, expiration int32) {
+func (y *Server) webhookRequestCreated(id, label string, expiration int32) {
 	if y.Webhooks != nil {
-		y.Webhooks.RequestCreated(id, expiration)
+		y.Webhooks.RequestCreated(id, label, expiration)
 	}
 }
 
-func (y *Server) webhookRequestFulfilled(id string) {
+func (y *Server) webhookRequestFulfilled(id, label string) {
 	if y.Webhooks != nil {
-		y.Webhooks.RequestFulfilled(id)
+		y.Webhooks.RequestFulfilled(id, label)
 	}
 }
 

--- a/pkg/server/webhook_test.go
+++ b/pkg/server/webhook_test.go
@@ -442,10 +442,13 @@ func TestWebhookRequestExpiredEvent(t *testing.T) {
 	sink := newWebhookSink(t)
 	notifier := newTestNotifier(t, WebhookConfig{URL: sink.server.URL})
 
-	notifier.RequestCreated("expiring-request", 3600)
+	notifier.RequestCreated("expiring-request", "Database credentials for Acme", 3600)
 	d := sink.waitForEvent(t)
 	if d.event.Event != WebhookEventRequestCreated {
 		t.Fatalf("expected created event, got %s", d.event.Event)
+	}
+	if d.event.Label != "Database credentials for Acme" {
+		t.Errorf("created event dropped the label: %+v", d.event)
 	}
 
 	// Force the deadline into the past; the watcher tick should pick it up.
@@ -461,6 +464,24 @@ func TestWebhookRequestExpiredEvent(t *testing.T) {
 	}
 	if d.event.Kind != WebhookKindRequest || d.event.ExpirationSeconds != 3600 {
 		t.Errorf("unexpected expired event fields: %+v", d.event)
+	}
+	// The request is gone by now, so the label can only come from the tracker.
+	if d.event.Label != "Database credentials for Acme" {
+		t.Errorf("expired event dropped the label: %+v", d.event)
+	}
+}
+
+func TestWebhookSecretEventsOmitLabel(t *testing.T) {
+	sink := newWebhookSink(t)
+	notifier := newTestNotifier(t, WebhookConfig{URL: sink.server.URL})
+
+	notifier.SecretCreated("labelless-secret", WebhookKindSecret, true, 3600)
+	d := sink.waitForEvent(t)
+	if d.event.Label != "" {
+		t.Errorf("secret events must not carry a label, got %q", d.event.Label)
+	}
+	if bytes.Contains(d.body, []byte(`"label"`)) {
+		t.Errorf("label key must be omitted from secret payloads, got %s", d.body)
 	}
 }
 


### PR DESCRIPTION
## Problem

A webhook receiver that gets `request.created`, `request.fulfilled` or `request.expired` cannot tell *which* request the event is about, beyond a fingerprint.

`secret_id` is `sha256(raw id)[:12]` — one-way by design, and rightly so. But that also means the receiver cannot call `GET /request/{key}` to resolve the label. The label is the only human-readable handle a request has, and it is the one field the payload leaves out.

Concretely: a journal of secret requests can show *that* a request was fulfilled, but never *what for*.

## Change

Add `label` to `WebhookEvent`, populated on the three `request.*` events.

- **`omitempty`** — secrets have no label, so `secret.*` payloads are byte-for-byte unchanged. Existing receivers see no difference.
- **`request.fulfilled`** reads the label from inside the `updateRequest` closure rather than issuing a second store read. It is reassigned on every attempt, so a retried transaction cannot leave a stale value behind.
- **`request.expired`** reads it from the expiry tracker — the only place it still exists at that point, since the request is already gone from the store.

## Why this is safe to emit

The label is already public: anyone holding the request link reads it back from `GET /request/{key}`. Emitting it to the operator's own webhook endpoint reveals nothing a receiver could not otherwise learn, and it does not weaken the payload's core property — no secret content, no decryption key, no raw ID.

`docs/webhooks.md` now says so explicitly, and warns that the label is logged, so it should not carry sensitive information.

## Example

```json
{
  "event": "request.created",
  "timestamp": "2026-06-11T13:37:00.000000042Z",
  "secret_id": "d22b8554f618",
  "kind": "request",
  "label": "Database credentials for Acme",
  "one_time": false,
  "expiration_seconds": 3600
}
```

## Tests

- `TestWebhookRequestExpiredEvent` extended: asserts the label survives to the expired event, i.e. that it really is carried by the tracker and not read back from a store entry that no longer exists.
- `TestWebhookSecretEventsOmitLabel` added: asserts `secret.*` payloads contain no `label` key at all, guarding the `omitempty` contract.

Both were mutation-checked — removing the propagation makes them fail.

`gofmt`, `go build ./...`, `go vet ./...` and `go test ./pkg/...` all pass.

## Notes

Also verified end-to-end against a real deployment (14.4.0 + this change): `label` present on `request.created` and `request.fulfilled`, absent from `secret.*`, HMAC signature unaffected.

Happy to adjust naming or scope — e.g. if you'd rather gate it behind a flag, or omit it from `request.expired`.