### PR TITLE
Fix custom color overrides resetting base theme to light (#3687)

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -153,6 +153,5 @@ services:
 
 ## Notes
 
-- `--theme-light` and `--theme-dark` must not be set to `custom-light` or `custom-dark` — those names are reserved for internal use.
 - Custom theme variables that do not start with `--color-` are rejected at startup.
 - When any branding flag is set without a `--license-key`, the server starts but the customisation is not applied.

--- a/website/src/shared/theme/ThemeProvider.tsx
+++ b/website/src/shared/theme/ThemeProvider.tsx
@@ -5,8 +5,6 @@ import {
   type LogicalTheme,
   getInitialLogicalTheme,
   THEME_STORAGE_KEY,
-  CUSTOM_LIGHT_THEME_NAME,
-  CUSTOM_DARK_THEME_NAME,
 } from './theme';
 
 interface ThemeContextValue {
@@ -23,11 +21,18 @@ export function useTheme(): ThemeContextValue {
   return ctx;
 }
 
+// injectCustomThemeStyle layers a handful of custom `--color-*` overrides on top
+// of an existing DaisyUI base theme. The overrides are scoped to the base
+// theme's own `data-theme` selector so all of the base theme's other variables
+// (background, text, etc.) keep applying — only the listed tokens change. A
+// `:root` prefix raises specificity above DaisyUI's plain `[data-theme=…]` rule
+// so the overrides win regardless of stylesheet source order.
 function injectCustomThemeStyle(
-  name: string,
+  slot: 'light' | 'dark',
+  baseTheme: string,
   vars: Record<string, string> | undefined,
 ) {
-  const styleId = `yopass-theme-${name}`;
+  const styleId = `yopass-theme-${slot}`;
   document.getElementById(styleId)?.remove();
   if (!vars) return;
   const css = Object.entries(vars)
@@ -35,7 +40,7 @@ function injectCustomThemeStyle(
     .join('\n');
   const style = document.createElement('style');
   style.id = styleId;
-  style.textContent = `[data-theme="${name}"] {\n${css}\n}`;
+  style.textContent = `:root[data-theme="${baseTheme}"] {\n${css}\n}`;
   document.head.appendChild(style);
 }
 
@@ -49,23 +54,20 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   } = useConfig();
   const [mode, setMode] = useState<LogicalTheme>(getInitialLogicalTheme);
 
-  const lightName = THEME_CUSTOM_LIGHT ? CUSTOM_LIGHT_THEME_NAME : THEME_LIGHT;
-  const darkName = THEME_CUSTOM_DARK ? CUSTOM_DARK_THEME_NAME : THEME_DARK;
+  useEffect(() => {
+    injectCustomThemeStyle('light', THEME_LIGHT, THEME_CUSTOM_LIGHT);
+    injectCustomThemeStyle('dark', THEME_DARK, THEME_CUSTOM_DARK);
+  }, [THEME_LIGHT, THEME_DARK, THEME_CUSTOM_LIGHT, THEME_CUSTOM_DARK]);
 
   useEffect(() => {
-    injectCustomThemeStyle(CUSTOM_LIGHT_THEME_NAME, THEME_CUSTOM_LIGHT);
-    injectCustomThemeStyle(CUSTOM_DARK_THEME_NAME, THEME_CUSTOM_DARK);
-  }, [THEME_CUSTOM_LIGHT, THEME_CUSTOM_DARK]);
-
-  useEffect(() => {
-    const daisyTheme = mode === 'dark' ? darkName : lightName;
+    const daisyTheme = mode === 'dark' ? THEME_DARK : THEME_LIGHT;
     document.documentElement.setAttribute('data-theme', daisyTheme);
     try {
       localStorage.setItem(THEME_STORAGE_KEY, mode);
     } catch {
       void 0;
     }
-  }, [mode, lightName, darkName]);
+  }, [mode, THEME_LIGHT, THEME_DARK]);
 
   useEffect(() => {
     if (APP_NAME) document.title = APP_NAME;

--- a/website/src/shared/theme/ThemeProvider.tsx
+++ b/website/src/shared/theme/ThemeProvider.tsx
@@ -27,6 +27,10 @@ export function useTheme(): ThemeContextValue {
 // (background, text, etc.) keep applying — only the listed tokens change. A
 // `:root` prefix raises specificity above DaisyUI's plain `[data-theme=…]` rule
 // so the overrides win regardless of stylesheet source order.
+//
+// `baseTheme` comes from the untrusted `/config` response, so it is escaped with
+// `CSS.escape` before being interpolated into the selector; the variable values
+// are already sanitised by `asThemeVars` in ConfigContext.
 function injectCustomThemeStyle(
   slot: 'light' | 'dark',
   baseTheme: string,
@@ -40,7 +44,7 @@ function injectCustomThemeStyle(
     .join('\n');
   const style = document.createElement('style');
   style.id = styleId;
-  style.textContent = `:root[data-theme="${baseTheme}"] {\n${css}\n}`;
+  style.textContent = `:root[data-theme="${CSS.escape(baseTheme)}"] {\n${css}\n}`;
   document.head.appendChild(style);
 }
 

--- a/website/src/shared/theme/theme.ts
+++ b/website/src/shared/theme/theme.ts
@@ -5,9 +5,6 @@ export const DEFAULT_DARK_THEME = 'dim';
 
 export const THEME_STORAGE_KEY = 'themeMode';
 
-export const CUSTOM_LIGHT_THEME_NAME = 'custom-light';
-export const CUSTOM_DARK_THEME_NAME = 'custom-dark';
-
 export function getInitialLogicalTheme(): LogicalTheme {
   try {
     const stored = localStorage.getItem(

--- a/website/tests/settings-menu.spec.ts
+++ b/website/tests/settings-menu.spec.ts
@@ -106,6 +106,34 @@ test.describe('Settings menu', () => {
     await expect(html).toHaveAttribute('data-theme', 'emerald');
   });
 
+  test('custom color override keeps the base theme background', async ({
+    page,
+  }) => {
+    // Regression for #3687: a single custom override under a dark base theme
+    // must not reset the background to light. The base theme stays applied and
+    // only the overridden token changes.
+    await mockAPI.mockConfigEndpoint({
+      THEME_LIGHT: 'corporate',
+      THEME_DARK: 'business',
+      THEME_CUSTOM_DARK: { '--color-primary': 'oklch(65% 0.25 260)' },
+    });
+    await open(page);
+
+    const html = page.locator('html');
+    await page.locator('[data-testid="theme-toggle"]').click();
+    await expect(html).toHaveAttribute('data-theme', 'business');
+
+    // The business base theme defines a dark base-100 (background). If the
+    // override had wiped the base theme it would fall back to white.
+    const bg = await page.evaluate(() =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--color-base-100')
+        .trim(),
+    );
+    expect(bg).not.toBe('');
+    expect(bg).not.toMatch(/#fff|white|oklch\(1 0 0\)|rgb\(255, 255, 255\)/i);
+  });
+
   test('date format toggle shows a live preview', async ({ page }) => {
     await mockAPI.mockConfigEndpoint();
     await open(page);


### PR DESCRIPTION
Custom theme overrides were injected under a synthetic data-theme name (custom-light/custom-dark) that DaisyUI does not register, so only the overridden variables applied and every other base-theme token — including --color-base-100 (background) — fell back to defaults, turning the UI white.

Keep data-theme on the real base theme so DaisyUI applies its full variable set, and inject overrides scoped to that base theme with a :root prefix so they layer on top regardless of stylesheet source order.