### PR TITLE
Group @docusaurus/* dependency updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,7 @@ updates:
   groups:
     docusaurus:
       patterns:
-        - "@docusaurus/*"
+      - "@docusaurus/*"
 - package-ecosystem: gomod
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,10 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
+  groups:
+    docusaurus:
+      patterns:
+      - "@docusaurus/*"
 - package-ecosystem: gomod
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,7 @@ updates:
   groups:
     docusaurus:
       patterns:
-      - "@docusaurus/*"
+        - "@docusaurus/*"
 - package-ecosystem: gomod
   directory: "/"
   schedule:


### PR DESCRIPTION
## Summary
- Microsite dependabot updates for `@docusaurus/*` packages fail when core/preset-classic/plugin versions drift apart, since they must be bumped in lockstep.
- Adds a dependabot `groups` config for the `/microsite` npm ecosystem so all `@docusaurus/*` packages are bumped together in a single PR.

## Test plan
- [ ] Validated YAML parses correctly
- [ ] Confirm dependabot opens a single grouped PR for docusaurus packages on the next scheduled run