### PR TITLE
feat(api): add token-based authentication for API requests

### DIFF
--- a/cmd/yopass/main.go
+++ b/cmd/yopass/main.go
@@ -47,6 +47,7 @@ func init() {
 	// Use build-time values if set; otherwise, fall back to hardcoded defaults.
 	// Build with -ldflags "-X main.defaultAPI=https://your-custom-api.com -X main.defaultURL=https://your-custom-url.com" to override defaults
 	viper.SetDefault("api", defaultAPI)
+	viper.SetDefault("api-token", "")
 	viper.SetDefault("url", defaultURL)
 	viper.SetDefault("one-time", true)
 	viper.SetDefault("expiration", "1h")
@@ -69,6 +70,7 @@ func init() {
 	// Command-line flags
 	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
 	pflag.String("api", viper.GetString("api"), "Yopass API server location")
+	pflag.String("api-token", viper.GetString("api-token"), "Bearer API token for server authentication")
 	pflag.String("decrypt", viper.GetString("decrypt"), "Decrypt secret URL")
 	pflag.String("expiration", viper.GetString("expiration"), "Duration after which secret will be deleted [1h, 1d, 1w]")
 	pflag.String("file", viper.GetString("file"), "Read secret from file instead of stdin")
@@ -120,7 +122,7 @@ func decrypt(out io.Writer) error {
 		return decryptFile(out, id, key)
 	}
 
-	msg, err := yopass.Fetch(viper.GetString("api"), id)
+	msg, err := yopass.FetchWithToken(viper.GetString("api"), id, viper.GetString("api-token"))
 	if err != nil {
 		return fmt.Errorf("Failed to fetch secret: %w", err)
 	}
@@ -135,7 +137,7 @@ func decrypt(out io.Writer) error {
 }
 
 func decryptFile(out io.Writer, id, key string) error {
-	data, err := yopass.FetchFile(viper.GetString("api"), id)
+	data, err := yopass.FetchFileWithToken(viper.GetString("api"), id, viper.GetString("api-token"))
 	if err != nil {
 		return fmt.Errorf("Failed to fetch file: %w", err)
 	}
@@ -187,7 +189,7 @@ func encryptFileByName(filename string, out io.Writer) error {
 		return fmt.Errorf("Failed to encrypt file: %w", err)
 	}
 
-	id, err := yopass.StoreFile(viper.GetString("api"), data, exp, viper.GetBool("one-time"))
+	id, err := yopass.StoreFileWithToken(viper.GetString("api"), data, exp, viper.GetBool("one-time"), viper.GetString("api-token"))
 	if err != nil {
 		return fmt.Errorf("Failed to store file: %w", err)
 	}
@@ -228,11 +230,11 @@ func encrypt(in io.ReadCloser, out io.Writer) error {
 		return fmt.Errorf("Failed to encrypt secret: %w", err)
 	}
 
-	id, err := yopass.Store(viper.GetString("api"), yopass.Secret{
+	id, err := yopass.StoreWithToken(viper.GetString("api"), yopass.Secret{
 		Expiration: exp,
 		Message:    msg,
 		OneTime:    viper.GetBool("one-time"),
-	})
+	}, viper.GetString("api-token"))
 	if err != nil {
 		return fmt.Errorf("Failed to store secret: %w", err)
 	}
@@ -248,7 +250,7 @@ func encrypt(in io.ReadCloser, out io.Writer) error {
 // default key derivation, which every yopass server accepts. Decryption
 // needs no configuration since the S2K type is stored in the message.
 func argon2Enabled() bool {
-	config, err := yopass.FetchServerConfig(viper.GetString("api"))
+	config, err := yopass.FetchServerConfigWithToken(viper.GetString("api"), viper.GetString("api-token"))
 	return err == nil && config.Argon2
 }
 

--- a/cmd/yopass/main_test.go
+++ b/cmd/yopass/main_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
@@ -24,6 +26,7 @@ import (
 func resetViper() {
 	viper.Reset()
 	viper.SetDefault("api", defaultAPI)
+	viper.SetDefault("api-token", "")
 	viper.SetDefault("url", defaultURL)
 	viper.SetDefault("one-time", true)
 	viper.SetDefault("expiration", "1h")
@@ -62,6 +65,77 @@ func TestCLI(t *testing.T) {
 	}
 	if out.String() != msg {
 		t.Fatalf("expected secret to match original %q, got %q", msg, out.String())
+	}
+}
+
+func TestCLIUsesAPIToken(t *testing.T) {
+	var storedCiphertext string
+	var authHeader string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		switch r.URL.Path {
+		case "/config":
+			if authHeader != "Bearer test-token" {
+				t.Errorf("expected Authorization header %q, got %q", "Bearer test-token", authHeader)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]bool{"ARGON2": false})
+		case "/create/secret":
+			if authHeader != "Bearer test-token" {
+				t.Errorf("expected Authorization header %q, got %q", "Bearer test-token", authHeader)
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("reading body: %v", err)
+			}
+			var payload yopass.Secret
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("decoding payload: %v", err)
+			}
+			storedCiphertext = payload.Message
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": "test-id"})
+		case "/secret/test-id":
+			if authHeader != "Bearer test-token" {
+				t.Errorf("expected Authorization header %q, got %q", "Bearer test-token", authHeader)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": storedCiphertext})
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+
+	resetViper()
+	viper.Set("api", ts.URL)
+	viper.Set("api-token", "test-token")
+	viper.Set("url", ts.URL)
+	t.Cleanup(resetViper)
+
+	msg := "yopass CLI token auth test"
+	stdin, err := tempFile(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(stdin.Name())
+	defer stdin.Close()
+
+	var out bytes.Buffer
+	if err := encryptStdinOrFile(stdin, &out); err != nil {
+		t.Fatalf("expected no encryption error, got %q", err)
+	}
+	if !strings.HasPrefix(out.String(), ts.URL) {
+		t.Fatalf("expected encrypt to return secret URL, got %q", out.String())
+	}
+
+	viper.Set("decrypt", out.String())
+	out.Reset()
+	if err := decrypt(&out); err != nil {
+		t.Fatalf("expected no decryption error, got %q", err)
+	}
+	if out.String() != msg {
+		t.Fatalf("expected decrypted secret %q, got %q", msg, out.String())
+	}
+	if authHeader != "Bearer test-token" {
+		t.Fatalf("expected final Authorization header %q, got %q", "Bearer test-token", authHeader)
 	}
 }
 

--- a/pkg/yopass/client.go
+++ b/pkg/yopass/client.go
@@ -185,9 +185,15 @@ func FetchFileWithToken(server string, id string, token string) ([]byte, error) 
 }
 
 func setAuthorization(req *http.Request, token string) {
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return
 	}
+	if strings.HasPrefix(token, "Bearer ") || strings.HasPrefix(token, "bearer ") {
+		req.Header.Set("Authorization", token)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
 }
 
 func handleServerResponse(resp *http.Response) (string, error) {

--- a/pkg/yopass/client.go
+++ b/pkg/yopass/client.go
@@ -39,10 +39,22 @@ type ServerConfig struct {
 // FetchServerConfig retrieves the public configuration from the specified
 // server's /config endpoint.
 func FetchServerConfig(server string) (ServerConfig, error) {
+	return FetchServerConfigWithToken(server, "")
+}
+
+// FetchServerConfigWithToken retrieves the public configuration from the
+// specified server's /config endpoint using the provided Bearer token.
+func FetchServerConfigWithToken(server, token string) (ServerConfig, error) {
 	server = strings.TrimSuffix(server, "/")
 
 	var config ServerConfig
-	resp, err := HTTPClient.Get(server + "/config")
+	req, err := http.NewRequest(http.MethodGet, server+"/config", nil)
+	if err != nil {
+		return config, fmt.Errorf("could not create request: %w", err)
+	}
+	setAuthorization(req, token)
+
+	resp, err := HTTPClient.Do(req)
 	if err != nil {
 		return config, &ServerError{err: err}
 	}
@@ -59,9 +71,21 @@ func FetchServerConfig(server string) (ServerConfig, error) {
 
 // Fetch retrieves a secret by its ID from the specified server.
 func Fetch(server string, id string) (string, error) {
+	return FetchWithToken(server, id, "")
+}
+
+// FetchWithToken retrieves a secret by its ID from the specified server using
+// the provided Bearer token.
+func FetchWithToken(server string, id string, token string) (string, error) {
 	server = strings.TrimSuffix(server, "/")
 
-	resp, err := HTTPClient.Get(server + "/secret/" + id)
+	req, err := http.NewRequest(http.MethodGet, server+"/secret/"+id, nil)
+	if err != nil {
+		return "", fmt.Errorf("could not create request: %w", err)
+	}
+	setAuthorization(req, token)
+
+	resp, err := HTTPClient.Do(req)
 	if err != nil {
 		return "", &ServerError{err: err}
 	}
@@ -70,13 +94,26 @@ func Fetch(server string, id string) (string, error) {
 
 // Store sends the secret to the specified server and returns the secret ID.
 func Store(server string, s Secret) (string, error) {
+	return StoreWithToken(server, s, "")
+}
+
+// StoreWithToken sends the secret to the specified server and returns the
+// secret ID using the provided Bearer token.
+func StoreWithToken(server string, s Secret, token string) (string, error) {
 	server = strings.TrimSuffix(server, "/")
 
 	var j bytes.Buffer
 	if err := (json.NewEncoder(&j)).Encode(&s); err != nil {
 		return "", fmt.Errorf("could not encode request: %w", err)
 	}
-	resp, err := HTTPClient.Post(server+"/create/secret", "application/json", &j)
+	req, err := http.NewRequest(http.MethodPost, server+"/create/secret", &j)
+	if err != nil {
+		return "", fmt.Errorf("could not create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	setAuthorization(req, token)
+
+	resp, err := HTTPClient.Do(req)
 	if err != nil {
 		return "", &ServerError{err: err}
 	}
@@ -86,15 +123,22 @@ func Store(server string, s Secret) (string, error) {
 // StoreFile uploads encrypted file data to the streaming endpoint and returns the file ID.
 // The filename is embedded in the OpenPGP metadata by the caller via EncryptBinary.
 func StoreFile(server string, data []byte, expiration int32, oneTime bool) (string, error) {
+	return StoreFileWithToken(server, data, expiration, oneTime, "")
+}
+
+// StoreFileWithToken uploads encrypted file data to the streaming endpoint and
+// returns the file ID using the provided Bearer token.
+func StoreFileWithToken(server string, data []byte, expiration int32, oneTime bool, token string) (string, error) {
 	server = strings.TrimSuffix(server, "/")
 
-	req, err := http.NewRequest("POST", server+"/create/file", bytes.NewReader(data))
+	req, err := http.NewRequest(http.MethodPost, server+"/create/file", bytes.NewReader(data))
 	if err != nil {
 		return "", fmt.Errorf("could not create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("X-Yopass-Expiration", fmt.Sprintf("%d", expiration))
 	req.Header.Set("X-Yopass-OneTime", fmt.Sprintf("%t", oneTime))
+	setAuthorization(req, token)
 
 	resp, err := HTTPClient.Do(req)
 	if err != nil {
@@ -106,13 +150,20 @@ func StoreFile(server string, data []byte, expiration int32, oneTime bool) (stri
 // FetchFile retrieves a streaming file by its ID and returns the encrypted body.
 // The filename is embedded in the OpenPGP metadata; call Decrypt() to obtain it.
 func FetchFile(server string, id string) ([]byte, error) {
+	return FetchFileWithToken(server, id, "")
+}
+
+// FetchFileWithToken retrieves a streaming file by its ID and returns the
+// encrypted body using the provided Bearer token.
+func FetchFileWithToken(server string, id string, token string) ([]byte, error) {
 	server = strings.TrimSuffix(server, "/")
 
-	req, err := http.NewRequest("GET", server+"/file/"+id, nil)
+	req, err := http.NewRequest(http.MethodGet, server+"/file/"+id, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not create request: %w", err)
 	}
 	req.Header.Set("Accept", "application/octet-stream")
+	setAuthorization(req, token)
 
 	resp, err := HTTPClient.Do(req)
 	if err != nil {
@@ -131,6 +182,12 @@ func FetchFile(server string, id string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+func setAuthorization(req *http.Request, token string) {
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 }
 
 func handleServerResponse(resp *http.Response) (string, error) {

--- a/pkg/yopass/client_test.go
+++ b/pkg/yopass/client_test.go
@@ -3,6 +3,8 @@ package yopass_test
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -245,6 +247,71 @@ func TestFetchServerConfigError(t *testing.T) {
 	var serverErr *yopass.ServerError
 	if !errors.As(err, &serverErr) {
 		t.Fatalf("expected ServerError, got %T", err)
+	}
+}
+
+func TestTokenAuthHeaders(t *testing.T) {
+	var storedSecret string
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		switch r.URL.Path {
+		case "/config":
+			if gotAuth != "Bearer test-token" {
+				t.Errorf("expected Authorization header %q, got %q", "Bearer test-token", gotAuth)
+			}
+			_, _ = io.WriteString(w, `{"ARGON2":false}`)
+		case "/secret/test-secret":
+			if gotAuth != "Bearer test-token" {
+				t.Errorf("expected Authorization header %q, got %q", "Bearer test-token", gotAuth)
+			}
+			_, _ = io.WriteString(w, `{"message":"secret"}`)
+		case "/create/secret":
+			if gotAuth != "Bearer test-token" {
+				t.Errorf("expected Authorization header %q, got %q", "Bearer test-token", gotAuth)
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("reading body: %v", err)
+			}
+			storedSecret = string(body)
+			_, _ = io.WriteString(w, `{"message":"test-secret"}`)
+		case "/create/file":
+			if gotAuth != "Bearer test-token" {
+				t.Errorf("expected Authorization header %q, got %q", "Bearer test-token", gotAuth)
+			}
+			_, _ = io.WriteString(w, `{"message":"test-file"}`)
+		case "/file/test-file":
+			if gotAuth != "Bearer test-token" {
+				t.Errorf("expected Authorization header %q, got %q", "Bearer test-token", gotAuth)
+			}
+			_, _ = io.WriteString(w, `encrypted-file-data`)
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+
+	if _, err := yopass.FetchServerConfigWithToken(ts.URL, "test-token"); err != nil {
+		t.Fatalf("FetchServerConfigWithToken failed: %v", err)
+	}
+	if _, err := yopass.FetchWithToken(ts.URL, "test-secret", "test-token"); err != nil {
+		t.Fatalf("FetchWithToken failed: %v", err)
+	}
+	if _, err := yopass.StoreWithToken(ts.URL, yopass.Secret{Expiration: 3600, Message: "hello"}, "test-token"); err != nil {
+		t.Fatalf("StoreWithToken failed: %v", err)
+	}
+	if storedSecret == "" {
+		t.Fatal("expected request body to be captured for StoreWithToken")
+	}
+	if _, err := yopass.StoreFileWithToken(ts.URL, []byte("file-data"), 3600, true, "test-token"); err != nil {
+		t.Fatalf("StoreFileWithToken failed: %v", err)
+	}
+	if _, err := yopass.FetchFileWithToken(ts.URL, "test-file", "test-token"); err != nil {
+		t.Fatalf("FetchFileWithToken failed: %v", err)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Fatalf("expected final Authorization header %q, got %q", "Bearer test-token", gotAuth)
 	}
 }
 


### PR DESCRIPTION
Implemented functions to support Bearer token authentication for fetching and storing secrets, as well as retrieving server configuration. Updated existing methods to utilize the new token parameter for enhanced security.

Includes tests to verify correct handling of authorization headers.

This is not the cleanest solution I could think of, but it was the easiest to implement with respect to my ability to write Go..... Somebody should definitely look over this 😄 

The basic idea here is that the yopass cli client now accepts the api token as a straight parameter and passes it along to the server.

I updated and added the tests to cover this path.