### PR TITLE
fix(server): validate PGP armor properly in isPGPEncrypted

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,15 @@ Yopass is designed with security as the primary focus:
 - **End-to-End Encryption**: Uses OpenPGP encryption with strong cryptographic standards
 - **One-Time Access**: Configurable one-time secret viewing to prevent replay attacks
 - **Minimal Data Retention**: Secrets automatically expire and are permanently deleted
-- **No Plain Text Storage**: Server never has access to unencrypted secrets
+- **No Plain Text Storage**: The official clients encrypt before anything leaves the browser, so the server stores and serves only ciphertext
+
+This last property is guaranteed by the client, not enforced by the server. The
+server checks that a submitted message is a well-formed armored `PGP MESSAGE`
+and rejects anything else, but armor alone cannot prove that a payload is
+genuinely encrypted, and no server-side check could: a caller can always
+encrypt with a key they control. Treat the API as accepting arbitrary
+caller-supplied ciphertext, and do not build downstream controls on the
+assumption that content which passed Yopass's validation is opaque.
 
 ### Security Features
 

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -289,11 +289,11 @@ func maxArmoredFileLength(n int64) int64 {
 // are allowed the armored encoding of a file up to effectiveRequestFileSize
 // must fit too.
 func (y *Server) fulfillRequestBodyLimit() int64 {
-	limit := int64(y.MaxLength) + 4096
+	limit := jsonBodyLimit(int64(y.MaxLength))
 	if y.DisableUpload {
 		return limit
 	}
-	if fileLimit := maxArmoredFileLength(y.effectiveRequestFileSize()) + 4096; fileLimit > limit {
+	if fileLimit := jsonBodyLimit(maxArmoredFileLength(y.effectiveRequestFileSize())); fileLimit > limit {
 		return fileLimit
 	}
 	return limit
@@ -315,7 +315,7 @@ func (y *Server) fulfillSecretRequest(w http.ResponseWriter, request *http.Reque
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			audit.failure("request body too large")
-			jsonError(w, http.StatusRequestEntityTooLarge, "Request body too large")
+			tooLarge(w, request.Body)
 			return
 		}
 		audit.failure("unable to parse json")

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -339,12 +339,6 @@ func (y *Server) fulfillSecretRequest(w http.ResponseWriter, request *http.Reque
 		return
 	}
 
-	if !isPGPEncrypted(body.Message) {
-		audit.failure("message not PGP encrypted")
-		jsonError(w, http.StatusBadRequest, "Message must be PGP encrypted")
-		return
-	}
-
 	switch kind {
 	case RequestSecretKindText:
 		if len(body.Message) > y.MaxLength {
@@ -358,6 +352,12 @@ func (y *Server) fulfillSecretRequest(w http.ResponseWriter, request *http.Reque
 			jsonError(w, http.StatusRequestEntityTooLarge, "File too large")
 			return
 		}
+	}
+
+	if !isPGPEncrypted(body.Message) {
+		audit.failure("message not PGP encrypted")
+		jsonError(w, http.StatusBadRequest, "Message must be PGP encrypted")
+		return
 	}
 
 	err := y.updateRequest(id, func(req *SecretRequest) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -213,12 +215,21 @@ func (y *Server) createSecret(w http.ResponseWriter, request *http.Request) {
 	session, _ := y.getSession(request)
 	audit := y.newAuditor("secret.created", y.getRealClientIP(request), session)
 
-	decoder := json.NewDecoder(request.Body)
+	// Cap the body so an oversized message is rejected before it is buffered,
+	// rather than after, by the MaxLength check below. The slack covers the
+	// JSON envelope around the message.
+	reader := http.MaxBytesReader(w, request.Body, int64(y.MaxLength)+4096)
 	var body struct {
 		yopass.Secret
 		Receipt bool `json:"receipt"`
 	}
-	if err := decoder.Decode(&body); err != nil {
+	if err := json.NewDecoder(reader).Decode(&body); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			audit.failure("request body too large")
+			jsonError(w, http.StatusRequestEntityTooLarge, "Request body too large")
+			return
+		}
 		y.Logger.Debug("Unable to decode request", zap.Error(err))
 		jsonError(w, http.StatusBadRequest, "Unable to parse json")
 		return
@@ -234,15 +245,15 @@ func (y *Server) createSecret(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	if !isPGPEncrypted(s.Message) {
-		audit.failure("message not PGP encrypted")
-		jsonError(w, http.StatusBadRequest, "Message must be PGP encrypted")
-		return
-	}
-
 	if len(s.Message) > y.MaxLength {
 		audit.failure("message too long")
 		jsonError(w, http.StatusBadRequest, "The encrypted message is too long")
+		return
+	}
+
+	if !isPGPEncrypted(s.Message) {
+		audit.failure("message not PGP encrypted")
+		jsonError(w, http.StatusBadRequest, "Message must be PGP encrypted")
 		return
 	}
 
@@ -667,6 +678,10 @@ func (y *Server) HTTPHandler() http.Handler {
 
 const keyParameter = "{key:(?:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}|[a-zA-Z0-9]{22})}"
 
+// pgpMessageType is the only armor block type yopass accepts; go-crypto
+// exports constants for key and signature blocks but not for messages.
+const pgpMessageType = "PGP MESSAGE"
+
 // DefaultThemeLight and DefaultThemeDark are the built-in DaisyUI themes used
 // when no valid license overrides them. cmd/yopass-server uses them as the
 // defaults for the --theme-light and --theme-dark flags.
@@ -701,15 +716,39 @@ func expirationInSeconds(s string) int32 {
 	return oneHour
 }
 
-// isPGPEncrypted verifies that the provided content is a valid PGP encrypted message
+// isPGPEncrypted verifies that the provided content is a well formed armored
+// PGP message.
+//
+// armor.Decode only parses the BEGIN header line; the base64 body and the END
+// marker are validated lazily as Block.Body is read, so the body must be
+// consumed to completion for the check to mean anything. The block type is
+// checked explicitly, otherwise any "-----BEGIN <anything>-----" line passes.
+//
+// The END marker is checked separately because go-crypto's line reader
+// reports a plain io.EOF for both "block ended" and "input ran out", so
+// reading the body cannot on its own tell a complete message from a
+// truncated one. The CRC24 checksum is not verified at all: go-crypto
+// stopped checking it once RFC 9580 made it optional.
+//
+// This is input hygiene, not a security boundary: armor says nothing about
+// whether the payload is really encrypted, and only the client can guarantee
+// that. It rejects truncated or mistyped ciphertext at submission time,
+// before the sender shares a link to a secret nobody can decrypt.
 func isPGPEncrypted(content string) bool {
 	if content == "" {
 		return false
 	}
 
-	// Try to decode the armored PGP message
-	_, err := armor.Decode(strings.NewReader(content))
-	return err == nil
+	block, err := armor.Decode(strings.NewReader(content))
+	if err != nil || block.Type != pgpMessageType {
+		return false
+	}
+
+	if _, err := io.Copy(io.Discard, block.Body); err != nil {
+		return false
+	}
+
+	return strings.Contains(content, "-----END "+pgpMessageType+"-----")
 }
 
 // corsMiddleware returns a middleware which sets CORS headers on all responses

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -93,6 +93,25 @@ func jsonError(w http.ResponseWriter, code int, message string) {
 	}
 }
 
+// jsonBodyLimit returns the request body cap for a JSON endpoint carrying an
+// armored message of up to n bytes. Armor wraps at 64 characters and JSON
+// escapes every newline as two bytes, so the envelope grows with the message
+// rather than by a constant; the fixed slack covers the surrounding fields.
+func jsonBodyLimit(n int64) int64 {
+	return n + n/64 + 4096
+}
+
+// tooLarge answers a request whose body exceeded its cap. It first discards
+// part of the unread remainder: Go closes the connection when a handler
+// returns while the client is still uploading, which the client sees as a
+// reset instead of this response. Discarding is O(1) memory, and the bound
+// stops an endless upload from being read forever. The 1MB bound is fixed;
+// revisit it if legitimate bodies get near it.
+func tooLarge(w http.ResponseWriter, body io.Reader) {
+	_, _ = io.CopyN(io.Discard, body, 1<<20)
+	jsonError(w, http.StatusRequestEntityTooLarge, "Request body too large")
+}
+
 // writeJSON writes v as a JSON response body with the given status code and
 // a correct application/json content type, logging encode failures.
 func (y *Server) writeJSON(w http.ResponseWriter, code int, v interface{}) {
@@ -216,9 +235,8 @@ func (y *Server) createSecret(w http.ResponseWriter, request *http.Request) {
 	audit := y.newAuditor("secret.created", y.getRealClientIP(request), session)
 
 	// Cap the body so an oversized message is rejected before it is buffered,
-	// rather than after, by the MaxLength check below. The slack covers the
-	// JSON envelope around the message.
-	reader := http.MaxBytesReader(w, request.Body, int64(y.MaxLength)+4096)
+	// rather than after, by the MaxLength check below.
+	reader := http.MaxBytesReader(w, request.Body, jsonBodyLimit(int64(y.MaxLength)))
 	var body struct {
 		yopass.Secret
 		Receipt bool `json:"receipt"`
@@ -227,7 +245,7 @@ func (y *Server) createSecret(w http.ResponseWriter, request *http.Request) {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			audit.failure("request body too large")
-			jsonError(w, http.StatusRequestEntityTooLarge, "Request body too large")
+			tooLarge(w, request.Body)
 			return
 		}
 		y.Logger.Debug("Unable to decode request", zap.Error(err))
@@ -727,8 +745,12 @@ func expirationInSeconds(s string) int32 {
 // The END marker is checked separately because go-crypto's line reader
 // reports a plain io.EOF for both "block ended" and "input ran out", so
 // reading the body cannot on its own tell a complete message from a
-// truncated one. The CRC24 checksum is not verified at all: go-crypto
-// stopped checking it once RFC 9580 made it optional.
+// truncated one. It has to be a suffix check rather than a search: Decode
+// skips everything before the BEGIN line and armor headers are free text, so
+// an END marker planted above or inside the header block would otherwise
+// vouch for a body that was never terminated. The CRC24 checksum is not
+// verified at all: go-crypto stopped checking it once RFC 9580 made it
+// optional.
 //
 // This is input hygiene, not a security boundary: armor says nothing about
 // whether the payload is really encrypted, and only the client can guarantee
@@ -744,11 +766,13 @@ func isPGPEncrypted(content string) bool {
 		return false
 	}
 
-	if _, err := io.Copy(io.Discard, block.Body); err != nil {
+	// An empty payload is well formed armor around nothing, which is still a
+	// secret nobody can decrypt.
+	if n, err := io.Copy(io.Discard, block.Body); err != nil || n == 0 {
 		return false
 	}
 
-	return strings.Contains(content, "-----END "+pgpMessageType+"-----")
+	return strings.HasSuffix(strings.TrimRight(content, " \t\r\n"), "-----END "+pgpMessageType+"-----")
 }
 
 // corsMiddleware returns a middleware which sets CORS headers on all responses

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -114,6 +114,17 @@ func (db *mockStatusDB) Update(key string, fn func(yopass.Secret) (yopass.Secret
 }
 func (db *mockStatusDB) Health() error { return nil }
 
+// armorShaped returns n bytes with armor's 64-character line wrapping: the
+// shape of an armored message, without valid content.
+func armorShaped(n int) string {
+	var b strings.Builder
+	for b.Len() < n {
+		b.WriteString(strings.Repeat("a", 64))
+		b.WriteString("\n")
+	}
+	return b.String()[:n]
+}
+
 func TestCreateSecret(t *testing.T) {
 	validPGPMessage := `-----BEGIN PGP MESSAGE-----
 Version: OpenPGP.js v4.10.8
@@ -179,6 +190,18 @@ sbfqaG/iDbp+qDOc98IagMyPrEqKDxnhVVOraXy5dD9RDsntLso=
 			output:    "Request body too large",
 			db:        &mockDB{},
 			maxLength: 1024,
+		},
+		{
+			// A message of exactly MaxLength is allowed, so the transport cap
+			// must leave room for JSON-escaping armor's line breaks: two bytes
+			// per wrapped line, which outgrows a constant slack.
+			name:       "message at max length reaches validation",
+			statusCode: 400,
+			body: strings.NewReader(fmt.Sprintf(`{"expiration": 3600, "message": "%s"}`,
+				strings.ReplaceAll(armorShaped(1<<20), "\n", "\\n"))),
+			output:    "Message must be PGP encrypted",
+			db:        &mockDB{},
+			maxLength: 1 << 20,
 		},
 		{
 			name:       "broken database",
@@ -1276,6 +1299,20 @@ Q5FI66ugslngweHlYODQ5IWLpbwMHdiymG7uoIKUusHi1lHUv+Gx0AA=
 			expected: true,
 		},
 		{
+			// openpgp.js terminates its armor with a newline.
+			name: "valid PGP message with trailing newline",
+			content: `-----BEGIN PGP MESSAGE-----
+Comment: https://yopass.se
+
+wy4ECQMILuOKAclPM2xgmtofvmWNo5/cfU8W54adSd82wxlrx9dHqfqpvPZnoaWF
+0uAB5FihFdqjbxKcLB3vS5UGETHhL1Hgi+Aj4biL4HPiNPEFqOBC5GYbD5oD7xUW
+Q5FI66ugslngweHlYODQ5IWLpbwMHdiymG7uoIKUusHi1lHUv+Gx0AA=
+=YaUx
+-----END PGP MESSAGE-----
+`,
+			expected: true,
+		},
+		{
 			name:     "empty string",
 			content:  "",
 			expected: false,
@@ -1323,6 +1360,24 @@ Q5FI66ugslngweHlYODQ5IWLpbwMHdiymG7uoIKUusHi1lHUv+Gx0AA=
 		{
 			name:     "missing END marker",
 			content:  "-----BEGIN PGP MESSAGE-----\n\naGVsbG8=\n",
+			expected: false,
+		},
+		{
+			// Decode skips everything before the BEGIN line, so a marker up
+			// there must not be mistaken for the block's terminator.
+			name:     "END marker before the BEGIN marker",
+			content:  "-----END PGP MESSAGE-----\n-----BEGIN PGP MESSAGE-----\n\naGVsbG8=\n",
+			expected: false,
+		},
+		{
+			// Armor header values are free text.
+			name:     "END marker planted in an armor header",
+			content:  "-----BEGIN PGP MESSAGE-----\nComment: -----END PGP MESSAGE-----\n\naGVsbG8=\n",
+			expected: false,
+		},
+		{
+			name:     "empty armor payload",
+			content:  "-----BEGIN PGP MESSAGE-----\n\n\n-----END PGP MESSAGE-----\n",
 			expected: false,
 		},
 		{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -154,6 +154,7 @@ sbfqaG/iDbp+qDOc98IagMyPrEqKDxnhVVOraXy5dD9RDsntLso=
 			body:       strings.NewReader(`{"expiration": 3600, "message": "hello world"}`),
 			output:     "Message must be PGP encrypted",
 			db:         &mockDB{},
+			maxLength:  10000,
 		},
 		{
 			name:       "message too long",
@@ -169,6 +170,15 @@ sbfqaG/iDbp+qDOc98IagMyPrEqKDxnhVVOraXy5dD9RDsntLso=
 			body:       strings.NewReader(fmt.Sprintf(`{"expiration": 10, "message": "%s"}`, strings.ReplaceAll(validPGPMessage, "\n", "\\n"))),
 			output:     "Invalid expiration specified",
 			db:         &mockDB{},
+		},
+		{
+			name:       "request body over the transport limit",
+			statusCode: 413,
+			body: strings.NewReader(fmt.Sprintf(`{"expiration": 3600, "message": "%s"}`,
+				strings.Repeat("a", 10*1024))),
+			output:    "Request body too large",
+			db:        &mockDB{},
+			maxLength: 1024,
 		},
 		{
 			name:       "broken database",
@@ -1294,6 +1304,48 @@ Q5FI66ugslngweHlYODQ5IWLpbwMHdiymG7uoIKUusHi1lHUv+Gx0AA=
 			name:     "Base64 encoded content",
 			content:  "SGVsbG8gV29ybGQ=",
 			expected: false,
+		},
+		{
+			name:     "header with typo in block type",
+			content:  "-----BEGIN PGP MESAGE-----\n\naGVsbG8=\n-----END PGP MESAGE-----\n",
+			expected: false,
+		},
+		{
+			name:     "arbitrary block type",
+			content:  "-----BEGIN LOL-----\n\naGVsbG8=\n-----END LOL-----\n",
+			expected: false,
+		},
+		{
+			name:     "public key block instead of message",
+			content:  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\n\n-----END PGP PUBLIC KEY BLOCK-----\n",
+			expected: false,
+		},
+		{
+			name:     "missing END marker",
+			content:  "-----BEGIN PGP MESSAGE-----\n\naGVsbG8=\n",
+			expected: false,
+		},
+		{
+			name:     "plaintext body inside armor headers",
+			content:  "-----BEGIN PGP MESSAGE-----\n\nmy password is hunter2\n-----END PGP MESSAGE-----\n",
+			expected: false,
+		},
+		{
+			name:     "truncated base64 body",
+			content:  "-----BEGIN PGP MESSAGE-----\n\nwy4ECQMIRthQ3aO85Nv\n-----END PGP MESSAGE-----\n",
+			expected: false,
+		},
+		{
+			name: "valid message without checksum line",
+			// The CRC24 checksum is optional since RFC 9580 and go-crypto no
+			// longer verifies it, so a message lacking one is still accepted.
+			content: `-----BEGIN PGP MESSAGE-----
+
+wy4ECQMIRthQ3aO85NvgAfASIX3dTwsFVt0gshPu7n1tN05e8rpqxOk6PYNm
+xtt90k4BqHuTCLNlFRJjuiuE8zdIc+j5zTN5zihxUReVqokeqULLOx2FBMHZ
+sbfqaG/iDbp+qDOc98IagMyPrEqKDxnhVVOraXy5dD9RDsntLso=
+-----END PGP MESSAGE-----`,
+			expected: true,
 		},
 	}
 


### PR DESCRIPTION
armor.Decode only parses the BEGIN header line. The base64 body and the END marker are validated lazily as Block.Body is read, and the check never read Body or looked at Block.Type, so any string shaped like an armor header was accepted -- including arbitrary block types, wrong block types, truncated messages, and plaintext wrapped in headers.

Check the block type is PGP MESSAGE, consume the body to completion, and verify the END marker. The END marker needs a separate check because go-crypto's lineReader returns a bare io.EOF both when it hits the end of a block and when the input runs out, so reading the body cannot distinguish a complete message from a truncated one. The CRC24 checksum stays unverified: go-crypto stopped checking it once RFC 9580 made it optional.

This is input hygiene, not a security boundary. Armor cannot prove a payload is encrypted -- a caller can always encrypt with a key they control -- so the value is rejecting truncated or mistyped ciphertext at submission time, before the sender shares a link to a secret nobody can decrypt. SECURITY.md is reworded to state that "No Plain Text Storage" is guaranteed by the client rather than enforced by the server.

Also run the MaxLength check before armor decoding in createSecret and fulfillSecretRequest, and cap the createSecret request body with MaxBytesReader, which it lacked entirely.