### PR TITLE
fix(server): clamp HTTP method label in metrics middleware

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -861,10 +861,22 @@ func newMetricsMiddleware(reg prometheus.Registerer) func(http.Handler) http.Han
 			rec := statusCodeRecorder{ResponseWriter: w, statusCode: http.StatusOK}
 			handler.ServeHTTP(&rec, r)
 			path := normalizedPath(r)
-			requests.WithLabelValues(r.Method, path, strconv.Itoa(rec.statusCode)).Inc()
-			duration.WithLabelValues(r.Method, path).Observe(time.Since(start).Seconds())
+			method := normalizedMethod(r.Method)
+			requests.WithLabelValues(method, path, strconv.Itoa(rec.statusCode)).Inc()
+			duration.WithLabelValues(method, path).Observe(time.Since(start).Seconds())
 		})
 	}
+}
+
+// normalizedMethod clamps the request method to a fixed set so a client
+// cannot inflate Prometheus label cardinality with arbitrary method tokens.
+func normalizedMethod(method string) string {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodOptions:
+		return method
+	}
+	return "<other>"
 }
 
 // normalizedPath returns a normalized mux path template representation

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -873,7 +873,8 @@ func newMetricsMiddleware(reg prometheus.Registerer) func(http.Handler) http.Han
 func normalizedMethod(method string) string {
 	switch method {
 	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
-		http.MethodPatch, http.MethodDelete, http.MethodOptions:
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace:
 		return method
 	}
 	return "<other>"

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -462,12 +462,14 @@ func TestMetricsMethodCardinality(t *testing.T) {
 		h.ServeHTTP(httptest.NewRecorder(), req)
 	}
 
-	n, err := testutil.GatherAndCount(y.Registry, "yopass_http_requests_total")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 1 {
-		t.Fatalf(`Expected all unknown methods collapsed into 1 series; got %d`, n)
+	for _, name := range []string{"yopass_http_requests_total", "yopass_http_request_duration_seconds"} {
+		n, err := testutil.GatherAndCount(y.Registry, name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 1 {
+			t.Fatalf(`Expected all unknown methods collapsed into 1 %s series; got %d`, name, n)
+		}
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -450,6 +450,27 @@ yopass_http_requests_total{code="404",method="GET",path="/"} 1
 	}
 }
 
+func TestMetricsMethodCardinality(t *testing.T) {
+	y := newTestServer(t, &mockDB{}, 1, false)
+	h := y.HTTPHandler()
+
+	for _, method := range []string{"FOO", "BAR", "BAZ"} {
+		req, err := http.NewRequest(method, "/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		h.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	n, err := testutil.GatherAndCount(y.Registry, "yopass_http_requests_total")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf(`Expected all unknown methods collapsed into 1 series; got %d`, n)
+	}
+}
+
 func TestSecurityHeaders(t *testing.T) {
 	tt := []struct {
 		scheme       string


### PR DESCRIPTION
Arbitrary client-supplied methods created unbounded Prometheus label cardinality via the file-server catch-all route. Unknown methods now collapse to the existing <other> sentinel.