### PR TITLE
fix(server): don't delete file metadata on transient store errors

### DIFF
--- a/pkg/server/filestore.go
+++ b/pkg/server/filestore.go
@@ -9,6 +9,8 @@ import (
 // Metadata (expiration, filename, one_time) is stored separately in the Database.
 type FileStore interface {
 	Save(ctx context.Context, key string, data io.Reader, contentLength int64, expiration int32) error
+	// Load returns an error wrapping ErrKeyNotFound when the object definitely
+	// does not exist. Any other error means "unreachable", not "gone".
 	Load(ctx context.Context, key string) (io.ReadCloser, int64, error)
 	Delete(ctx context.Context, key string) error
 	Health(ctx context.Context) error

--- a/pkg/server/filestore_db_test.go
+++ b/pkg/server/filestore_db_test.go
@@ -27,7 +27,7 @@ func (db *testDB) Get(key string) (yopass.Secret, error) {
 	defer db.mu.Unlock()
 	s, ok := db.store[key]
 	if !ok {
-		return yopass.Secret{}, fmt.Errorf("not found")
+		return yopass.Secret{}, ErrKeyNotFound
 	}
 	return s, nil
 }

--- a/pkg/server/filestore_disk.go
+++ b/pkg/server/filestore_disk.go
@@ -94,6 +94,9 @@ func (d *DiskFileStore) Save(_ context.Context, key string, data io.Reader, cont
 func (d *DiskFileStore) Load(_ context.Context, key string) (io.ReadCloser, int64, error) {
 	f, err := os.Open(d.binPath(key))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0, fmt.Errorf("could not open file: %v: %w", err, ErrKeyNotFound)
+		}
 		return nil, 0, fmt.Errorf("could not open file: %w", err)
 	}
 	stat, err := f.Stat()

--- a/pkg/server/filestore_s3.go
+++ b/pkg/server/filestore_s3.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 // S3FileStore stores encrypted files in an S3-compatible bucket.
@@ -78,6 +80,11 @@ func (s *S3FileStore) Load(ctx context.Context, key string) (io.ReadCloser, int6
 		Key:    aws.String(s.objectKey(key)),
 	})
 	if err != nil {
+		var noSuchKey *types.NoSuchKey
+		var notFound *types.NotFound
+		if errors.As(err, &noSuchKey) || errors.As(err, &notFound) {
+			return nil, 0, fmt.Errorf("s3 get failed: %v: %w", err, ErrKeyNotFound)
+		}
 		return nil, 0, fmt.Errorf("s3 get failed: %w", err)
 	}
 

--- a/pkg/server/memcached.go
+++ b/pkg/server/memcached.go
@@ -38,6 +38,9 @@ func (m *Memcached) Get(key string) (yopass.Secret, error) {
 	var s yopass.Secret
 
 	r, err := m.Client.Get(key)
+	if err == memcache.ErrCacheMiss {
+		return s, ErrKeyNotFound
+	}
 	if err != nil {
 		return s, err
 	}

--- a/pkg/server/redis.go
+++ b/pkg/server/redis.go
@@ -43,6 +43,9 @@ func (r *Redis) Status(key string) (yopass.Secret, error) {
 func (r *Redis) Get(key string) (yopass.Secret, error) {
 	var s yopass.Secret
 	v, err := r.client.Get(context.Background(), key).Result()
+	if err == redis.Nil {
+		return s, ErrKeyNotFound
+	}
 	if err != nil {
 		return s, err
 	}

--- a/pkg/server/server_stream.go
+++ b/pkg/server/server_stream.go
@@ -180,6 +180,14 @@ func (y *Server) streamDownload(w http.ResponseWriter, r *http.Request) {
 	reader, size, err := y.FileStore.Load(ctx, key)
 	if err != nil {
 		y.Logger.Error("Failed to load streaming file", zap.Error(err))
+		// Only a definite not-found means the file is gone. Anything else
+		// (network blip, credentials, disk) is transient — keep the metadata,
+		// the secret is still retrievable once the store recovers.
+		if !errors.Is(err, ErrKeyNotFound) {
+			audit.failure("file store unavailable")
+			jsonError(w, http.StatusServiceUnavailable, "File store temporarily unavailable")
+			return
+		}
 		// DB metadata exists but the file is gone — clean up the stale DB entry.
 		if !isOneTime {
 			if _, delErr := y.DB.Delete(streamKeyPrefix + key); delErr != nil {

--- a/pkg/server/server_stream.go
+++ b/pkg/server/server_stream.go
@@ -181,8 +181,9 @@ func (y *Server) streamDownload(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		y.Logger.Error("Failed to load streaming file", zap.Error(err))
 		// Only a definite not-found means the file is gone. Anything else
-		// (network blip, credentials, disk) is transient — keep the metadata,
-		// the secret is still retrievable once the store recovers.
+		// (network blip, credentials, disk) is transient. A multi-view secret
+		// keeps its metadata and is retrievable once the store recovers; a
+		// one-time secret was already claimed above and is lost either way.
 		if !errors.Is(err, ErrKeyNotFound) {
 			audit.failure("file store unavailable")
 			jsonError(w, http.StatusServiceUnavailable, "File store temporarily unavailable")

--- a/pkg/server/server_stream_test.go
+++ b/pkg/server/server_stream_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -369,6 +371,70 @@ func TestGetStreamSecretStatusNotFound(t *testing.T) {
 
 	if w.Code != 404 {
 		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+// flakyFileStore wraps a FileStore and fails Load with a transient error while
+// down is set.
+type flakyFileStore struct {
+	FileStore
+	down bool
+}
+
+func (f *flakyFileStore) Load(ctx context.Context, key string) (io.ReadCloser, int64, error) {
+	if f.down {
+		return nil, 0, errors.New("connection reset by peer")
+	}
+	return f.FileStore.Load(ctx, key)
+}
+
+// A transient store error must not destroy the secret: 503, metadata kept.
+func TestGetStreamSecretTransientStoreError(t *testing.T) {
+	db := newTestDB()
+	srv := newStreamTestServer(t, db)
+	store := &flakyFileStore{FileStore: srv.FileStore}
+	srv.FileStore = store
+	handler := srv.HTTPHandler()
+	key := doStreamUpload(t, handler)
+
+	store.down = true
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest("GET", "/file/"+key, nil))
+
+	if w.Code != 503 {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+	if _, err := db.Status(streamKeyPrefix + key); err != nil {
+		t.Fatalf("metadata was deleted on a transient error: %v", err)
+	}
+
+	// Once the store recovers the download works.
+	store.down = false
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest("GET", "/file/"+key, nil))
+	if w.Code != 200 {
+		t.Fatalf("expected 200 after recovery, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// A definite not-found still cleans up the stale metadata and 404s.
+func TestGetStreamSecretMissingFileCleansUp(t *testing.T) {
+	db := newTestDB()
+	srv := newStreamTestServer(t, db)
+	handler := srv.HTTPHandler()
+	key := doStreamUpload(t, handler)
+
+	if err := srv.FileStore.Delete(context.Background(), key); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest("GET", "/file/"+key, nil))
+	if w.Code != 404 {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+	if _, err := db.Status(streamKeyPrefix + key); err == nil {
+		t.Fatal("stale metadata was not cleaned up")
 	}
 }
 


### PR DESCRIPTION
FileStore.Load returned an undifferentiated error for both "object is gone" and "store is unreachable", and the download handler deleted the DB metadata in either case. A single S3 network blip or disk hiccup permanently destroyed a multi-view file secret.

Load now wraps the existing ErrKeyNotFound sentinel on definite not-found (os.IsNotExist, S3 NoSuchKey/NotFound, DB cache miss). The handler only cleans up stale metadata for that case; anything else returns 503 and keeps the record so the secret survives the outage.