### PR TITLE
fix(oidc): invalidate sessions on logout and cap cookie codec lifetime

### DIFF
--- a/pkg/server/oidc.go
+++ b/pkg/server/oidc.go
@@ -401,7 +401,8 @@ func (y *Server) oidcLogoutHandler(w http.ResponseWriter, r *http.Request) {
 		y.revokeSession(session.ID)
 	}
 	y.newAuditor("auth.logout", y.getRealClientIP(r), session).success()
-	http.Redirect(w, r, y.homeURL(), http.StatusFound)
+	// 303 so the browser follows up with GET instead of re-POSTing.
+	http.Redirect(w, r, y.homeURL(), http.StatusSeeOther)
 }
 
 // oidcMeHandler returns the current user's info or 401 if not authenticated.

--- a/pkg/server/oidc.go
+++ b/pkg/server/oidc.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gorilla/securecookie"
+	"github.com/jhaals/yopass/pkg/yopass"
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 	httphelper "github.com/zitadel/oidc/v3/pkg/http"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -23,7 +24,19 @@ import (
 
 const sessionCookieName = "yopass_session"
 
+// sessionMaxAge bounds how long a session cookie is accepted. It is applied
+// both to the browser cookie and to the securecookie codec, which otherwise
+// defaults to 30 days regardless of the cookie attribute.
+const sessionMaxAge = 24 * time.Hour
+
+// revokedSessionPrefix namespaces logged-out session IDs in the database. The
+// embedded slash keeps them out of reach of the /secret/{key} routes.
+const revokedSessionPrefix = "session-revoked/"
+
 type sessionData struct {
+	// ID identifies this login so that logout can revoke it server-side.
+	// Empty for API-token identities, which have no logout.
+	ID    string `json:"jti,omitempty"`
 	Sub   string `json:"sub"`
 	Email string `json:"email"`
 	Name  string `json:"name"`
@@ -56,7 +69,7 @@ func NewCookieCodec(key string) *securecookie.SecureCookie {
 		}
 	}
 
-	return securecookie.New(hashKey, encryptKey)
+	return securecookie.New(hashKey, encryptKey).MaxAge(int(sessionMaxAge.Seconds()))
 }
 
 // deriveKey returns a 32-byte key derived from masterHex using HKDF-SHA256 with label as info.
@@ -213,7 +226,36 @@ func (y *Server) getSession(r *http.Request) (*sessionData, error) {
 	if err := y.CookieCodec.Decode(sessionCookieName, cookie.Value, &s); err != nil {
 		return nil, err
 	}
+	if y.sessionRevoked(s.ID) {
+		return nil, nil
+	}
 	return &s, nil
+}
+
+// sessionRevoked reports whether the session ID has been logged out. Lookup
+// failures (backend down, or a memcached eviction of the revocation record)
+// count as not revoked: a storage outage must not sign every user out, and the
+// cookie expires on its own within sessionMaxAge either way.
+func (y *Server) sessionRevoked(id string) bool {
+	if id == "" || y.DB == nil {
+		return false
+	}
+	_, err := y.DB.Status(revokedSessionPrefix + id)
+	return err == nil
+}
+
+// revokeSession records the session ID as logged out for the remainder of its
+// maximum lifetime, so the stateless cookie stops being accepted.
+func (y *Server) revokeSession(id string) {
+	if id == "" || y.DB == nil {
+		return
+	}
+	if err := y.DB.Put(revokedSessionPrefix+id, yopass.Secret{
+		Expiration: int32(sessionMaxAge.Seconds()),
+		Message:    "revoked",
+	}); err != nil {
+		y.Logger.Error("failed to revoke session", zap.Error(err))
+	}
 }
 
 // setSession encodes and writes the session cookie.
@@ -238,7 +280,7 @@ func (y *Server) setSession(w http.ResponseWriter, r *http.Request, s *sessionDa
 		HttpOnly: true,
 		Secure:   secure,
 		SameSite: sameSite,
-		MaxAge:   int((24 * time.Hour).Seconds()),
+		MaxAge:   int(sessionMaxAge.Seconds()),
 	})
 	return nil
 }
@@ -331,6 +373,7 @@ func (y *Server) oidcUserinfoCallback(
 	}
 
 	s := &sessionData{
+		ID:    randomState(),
 		Sub:   info.Subject,
 		Email: info.Email,
 		Name:  info.Name,
@@ -354,6 +397,9 @@ func (y *Server) oidcCallbackHandler(w http.ResponseWriter, r *http.Request) {
 func (y *Server) oidcLogoutHandler(w http.ResponseWriter, r *http.Request) {
 	session, _ := y.getSession(r) // read before clearing so audit captures identity
 	y.clearSession(w, r)
+	if session != nil {
+		y.revokeSession(session.ID)
+	}
 	y.newAuditor("auth.logout", y.getRealClientIP(r), session).success()
 	http.Redirect(w, r, y.homeURL(), http.StatusFound)
 }
@@ -377,7 +423,9 @@ func (y *Server) oidcMeHandler(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusForbidden, "email domain not permitted")
 		return
 	}
-	y.writeJSON(w, http.StatusOK, s)
+	pub := *s
+	pub.ID = "" // internal, never exposed to the client
+	y.writeJSON(w, http.StatusOK, pub)
 }
 
 // requireAuthMiddleware returns 401 if there is no valid session, or 403 if

--- a/pkg/server/oidc_test.go
+++ b/pkg/server/oidc_test.go
@@ -449,6 +449,37 @@ func TestOIDCLogoutHandler(t *testing.T) {
 	}
 }
 
+// Replaying a captured session cookie after logout must not authenticate.
+func TestOIDCLogoutHandler_RevokesReplayedCookie(t *testing.T) {
+	s := newOIDCTestServer(t)
+	s.DB = newMemoryDB()
+
+	wSet := httptest.NewRecorder()
+	if err := s.setSession(wSet, httptest.NewRequest(http.MethodGet, "/", nil),
+		&sessionData{ID: randomState(), Sub: "u1", Email: "u1@example.com"}); err != nil {
+		t.Fatalf("setSession: %v", err)
+	}
+	captured := wSet.Result().Cookies()
+
+	replay := func() *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+		for _, c := range captured {
+			r.AddCookie(c)
+		}
+		return r
+	}
+
+	if sess, _ := s.getSession(replay()); sess == nil {
+		t.Fatal("session not valid before logout")
+	}
+
+	s.oidcLogoutHandler(httptest.NewRecorder(), replay())
+
+	if sess, _ := s.getSession(replay()); sess != nil {
+		t.Fatal("captured cookie still authenticates after logout")
+	}
+}
+
 func TestOIDCLogoutHandler_FrontendURL(t *testing.T) {
 	s := newOIDCTestServer(t)
 	s.FrontendURL = "https://app.example.com"

--- a/pkg/server/oidc_test.go
+++ b/pkg/server/oidc_test.go
@@ -431,15 +431,15 @@ func TestOIDCLogoutHandler(t *testing.T) {
 	wSet := httptest.NewRecorder()
 	_ = s.setSession(wSet, rSet, &sessionData{Sub: "u1"})
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/logout", nil)
+	r := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
 	for _, c := range wSet.Result().Cookies() {
 		r.AddCookie(c)
 	}
 	w := httptest.NewRecorder()
 	s.oidcLogoutHandler(w, r)
 
-	if w.Code != http.StatusFound {
-		t.Fatalf("got %d, want 302", w.Code)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("got %d, want 303", w.Code)
 	}
 	// Session cookie should be cleared.
 	for _, c := range w.Result().Cookies() {
@@ -461,21 +461,21 @@ func TestOIDCLogoutHandler_RevokesReplayedCookie(t *testing.T) {
 	}
 	captured := wSet.Result().Cookies()
 
-	replay := func() *http.Request {
-		r := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	replay := func(method, path string) *http.Request {
+		r := httptest.NewRequest(method, path, nil)
 		for _, c := range captured {
 			r.AddCookie(c)
 		}
 		return r
 	}
 
-	if sess, _ := s.getSession(replay()); sess == nil {
+	if sess, _ := s.getSession(replay(http.MethodGet, "/auth/me")); sess == nil {
 		t.Fatal("session not valid before logout")
 	}
 
-	s.oidcLogoutHandler(httptest.NewRecorder(), replay())
+	s.oidcLogoutHandler(httptest.NewRecorder(), replay(http.MethodPost, "/auth/logout"))
 
-	if sess, _ := s.getSession(replay()); sess != nil {
+	if sess, _ := s.getSession(replay(http.MethodGet, "/auth/me")); sess != nil {
 		t.Fatal("captured cookie still authenticates after logout")
 	}
 }
@@ -483,7 +483,7 @@ func TestOIDCLogoutHandler_RevokesReplayedCookie(t *testing.T) {
 func TestOIDCLogoutHandler_FrontendURL(t *testing.T) {
 	s := newOIDCTestServer(t)
 	s.FrontendURL = "https://app.example.com"
-	r := httptest.NewRequest(http.MethodGet, "/auth/logout", nil)
+	r := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
 	w := httptest.NewRecorder()
 	s.oidcLogoutHandler(w, r)
 


### PR DESCRIPTION
securecookie.New defaults to a 30-day maxAge, so the 24h MaxAge on the http.Cookie was a client-side hint only — a captured cookie stayed valid for 30 days. Set the codec maxAge to match.

Sessions now carry a random ID. Logout records it under a session-revoked/ prefix in the database with a 24h TTL, and getSession rejects any cookie whose ID is listed, so a replayed cookie no longer authenticates. Lookup failures fail open so a storage outage does not sign everyone out.