### PR TITLE
fix(website): refuse secret request links without a fingerprint

### DIFF
--- a/website/src/features/request-secret/ProvideSecret.tsx
+++ b/website/src/features/request-secret/ProvideSecret.tsx
@@ -44,6 +44,16 @@ export default function ProvideSecret() {
         setPageState('notFound');
         return;
       }
+      // The fingerprint in the link fragment never reaches the server, so a
+      // mismatch means the public key was replaced behind the requester's back.
+      // A missing fingerprint (truncated or hand-edited link) leaves nothing to
+      // verify against, so refuse before asking the server for anything —
+      // otherwise a broken link reports the request's state instead of the
+      // reason it will never be usable.
+      if (!fp) {
+        setPageState('integrityError');
+        return;
+      }
       const { data } = await getSecretRequest(key);
       if (cancelled) return;
       if (!data) {
@@ -52,14 +62,6 @@ export default function ProvideSecret() {
       }
       if (data.state === 'fulfilled') {
         setPageState('alreadyFulfilled');
-        return;
-      }
-      // The fingerprint in the link fragment never reaches the server, so a
-      // mismatch means the public key was replaced behind the requester's back.
-      // A missing fingerprint (truncated or hand-edited link) leaves nothing to
-      // verify against, so refuse rather than encrypt to an unverified key.
-      if (!fp) {
-        setPageState('integrityError');
         return;
       }
       try {

--- a/website/src/features/request-secret/ProvideSecret.tsx
+++ b/website/src/features/request-secret/ProvideSecret.tsx
@@ -56,17 +56,21 @@ export default function ProvideSecret() {
       }
       // The fingerprint in the link fragment never reaches the server, so a
       // mismatch means the public key was replaced behind the requester's back.
-      if (fp) {
-        try {
-          const fingerprint = await publicKeyFingerprint(data.public_key);
-          if (shortFingerprint(fingerprint) !== fp.toLowerCase()) {
-            setPageState('integrityError');
-            return;
-          }
-        } catch {
+      // A missing fingerprint (truncated or hand-edited link) leaves nothing to
+      // verify against, so refuse rather than encrypt to an unverified key.
+      if (!fp) {
+        setPageState('integrityError');
+        return;
+      }
+      try {
+        const fingerprint = await publicKeyFingerprint(data.public_key);
+        if (shortFingerprint(fingerprint) !== fp.toLowerCase()) {
           setPageState('integrityError');
           return;
         }
+      } catch {
+        setPageState('integrityError');
+        return;
       }
       setRequest(data);
       setPageState('ready');

--- a/website/tests/secret-request.spec.ts
+++ b/website/tests/secret-request.spec.ts
@@ -380,6 +380,24 @@ test.describe('Secret Requests', () => {
     ).toBeVisible();
   });
 
+  test('a link without a fingerprint refuses to render the form', async ({
+    page,
+  }) => {
+    await page.goto('/#/request');
+    await page.click('button:has-text("Create request link")');
+    await expect(page.locator('h2:has-text("Request created")')).toBeVisible({
+      timeout: 15000,
+    });
+    const link = await page.locator('code').textContent();
+
+    // A link truncated at the last slash has nothing to verify the server's
+    // public key against, so the form must not be offered.
+    await page.goto(link!.replace(/\/[0-9a-f]{16}$/, ''));
+    await expect(
+      page.locator('h2:has-text("Key verification failed")'),
+    ).toBeVisible();
+  });
+
   test('requests navbar entry is hidden when feature is disabled', async ({
     page,
   }) => {


### PR DESCRIPTION
The /r/:key route rendered the provide-secret form with the public key integrity check skipped entirely, since the check was conditional on the fingerprint being present in the URL. A link truncated at the last slash looked identical to a valid one and encrypted the secret to whatever key the server returned.

Fail closed instead: a missing fingerprint leaves nothing to verify against, so show the existing key verification error. The route stays registered so a mangled link gets that message rather than a bare 404.

No link the app generates is affected - requestLink has always included the fingerprint, and it is the documented format for direct API users.