### PR TITLE
fix(server): reject cross-origin state-changing requests with mismatched origin

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -775,24 +775,31 @@ func isPGPEncrypted(content string) bool {
 	return strings.HasSuffix(strings.TrimRight(content, " \t\r\n"), "-----END "+pgpMessageType+"-----")
 }
 
+// normalizeOrigin parses a URL or Origin value and returns scheme://host with
+// default ports stripped and the host lowercased, matching browser behavior.
+func normalizeOrigin(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return strings.ToLower(raw)
+	}
+	return u.Scheme + "://" + normalizeHost(u.Scheme, u.Host)
+}
+
 // corsMiddleware returns a middleware which sets CORS headers on all responses
 // and rejects cross-origin state-changing requests whose Origin does not match
 // the configured frontend URL (CSRF protection for split-origin deployments).
 func (y *Server) corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if y.FrontendURL != "" {
-			// Browsers send Origin as scheme://host (no path), so strip any path.
-			allowedOrigin := y.FrontendURL
-			if u, err := url.Parse(y.FrontendURL); err == nil && u.Host != "" {
-				allowedOrigin = u.Scheme + "://" + u.Host
-			}
+			// Browsers send Origin as scheme://host (no path), so normalize
+			// to scheme://lowercase-host with default ports stripped.
+			allowedOrigin := normalizeOrigin(y.FrontendURL)
 
 			// Reject state-changing requests with a mismatched Origin header.
-			// The Origin header is present on all cross-origin requests and
-			// same-origin POSTs in modern browsers; when absent the request
-			// is same-origin and SameSite cookies provide sufficient protection.
+			// When absent the origin cannot be verified; SameSite cookies
+			// provide sufficient protection in that case.
 			if origin := r.Header.Get("Origin"); origin != "" && r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions {
-				if origin != allowedOrigin {
+				if normalizeOrigin(origin) != allowedOrigin {
 					http.Error(w, "origin not allowed", http.StatusForbidden)
 					return
 				}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -776,20 +776,30 @@ func isPGPEncrypted(content string) bool {
 }
 
 // corsMiddleware returns a middleware which sets CORS headers on all responses
+// and rejects cross-origin state-changing requests whose Origin does not match
+// the configured frontend URL (CSRF protection for split-origin deployments).
 func (y *Server) corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if y.FrontendURL != "" {
-			// Credentialed cross-origin requests require a specific origin (not wildcard)
-			// and Access-Control-Allow-Credentials: true.
 			// Browsers send Origin as scheme://host (no path), so strip any path.
-			origin := y.FrontendURL
+			allowedOrigin := y.FrontendURL
 			if u, err := url.Parse(y.FrontendURL); err == nil && u.Host != "" {
-				origin = u.Scheme + "://" + u.Host
+				allowedOrigin = u.Scheme + "://" + u.Host
 			}
-			w.Header().Set("Access-Control-Allow-Origin", origin)
+
+			// Reject state-changing requests with a mismatched Origin header.
+			// The Origin header is present on all cross-origin requests and
+			// same-origin POSTs in modern browsers; when absent the request
+			// is same-origin and SameSite cookies provide sufficient protection.
+			if origin := r.Header.Get("Origin"); origin != "" && r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions {
+				if origin != allowedOrigin {
+					http.Error(w, "origin not allowed", http.StatusForbidden)
+					return
+				}
+			}
+
+			w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
-			// Vary: Origin tells caches that the response differs by origin so they
-			// do not serve a cached CORS response to a different requester.
 			w.Header().Add("Vary", "Origin")
 		} else {
 			w.Header().Set("Access-Control-Allow-Origin", y.CORSAllowOrigin)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -777,12 +777,22 @@ func isPGPEncrypted(content string) bool {
 
 // normalizeOrigin parses a URL or Origin value and returns scheme://host with
 // default ports stripped and the host lowercased, matching browser behavior.
+// Uses url.URL.Hostname/Port instead of net.SplitHostPort so IPv6 brackets
+// are preserved (e.g. https://[::1] stays valid).
 func normalizeOrigin(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil || u.Host == "" {
 		return strings.ToLower(raw)
 	}
-	return u.Scheme + "://" + normalizeHost(u.Scheme, u.Host)
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+	if port != "" && !((u.Scheme == "http" && port == "80") || (u.Scheme == "https" && port == "443")) {
+		host += ":" + port
+	}
+	return u.Scheme + "://" + host
 }
 
 // corsMiddleware returns a middleware which sets CORS headers on all responses

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2157,6 +2157,20 @@ func TestCORSMiddlewareRejectsCrossOriginCSRF(t *testing.T) {
 			t.Errorf("case-insensitive host should match, got 403")
 		}
 	})
+
+	t.Run("IPv6 literal origin matches", func(t *testing.T) {
+		s := newTestServer(t, &mockDB{}, 1, false)
+		s.FrontendURL = "https://[::1]:443"
+		h := s.HTTPHandler()
+		req := httptest.NewRequest(http.MethodPost, "/create/secret", nil)
+		req.Header.Set("Origin", "https://[::1]")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code == http.StatusForbidden {
+			t.Errorf("IPv6 origin with default port stripped should match, got 403")
+		}
+	})
 }
 
 // TestConfigHandler_LicensedBranches covers the optional config fields and

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2129,6 +2129,34 @@ func TestCORSMiddlewareRejectsCrossOriginCSRF(t *testing.T) {
 			t.Errorf("same-origin POST (no Origin header) should not be blocked")
 		}
 	})
+
+	t.Run("default port in frontend-url matches browser origin without port", func(t *testing.T) {
+		s := newTestServer(t, &mockDB{}, 1, false)
+		s.FrontendURL = "https://app.example.com:443"
+		h := s.HTTPHandler()
+		req := httptest.NewRequest(http.MethodPost, "/create/secret", nil)
+		req.Header.Set("Origin", "https://app.example.com")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code == http.StatusForbidden {
+			t.Errorf("default-port origin should match, got 403")
+		}
+	})
+
+	t.Run("mixed case host matches", func(t *testing.T) {
+		s := newTestServer(t, &mockDB{}, 1, false)
+		s.FrontendURL = "https://App.Example.COM"
+		h := s.HTTPHandler()
+		req := httptest.NewRequest(http.MethodPost, "/create/secret", nil)
+		req.Header.Set("Origin", "https://app.example.com")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code == http.StatusForbidden {
+			t.Errorf("case-insensitive host should match, got 403")
+		}
+	})
 }
 
 // TestConfigHandler_LicensedBranches covers the optional config fields and

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2084,6 +2084,53 @@ func TestCORSMiddlewareFrontendURLNoPath(t *testing.T) {
 	}
 }
 
+func TestCORSMiddlewareRejectsCrossOriginCSRF(t *testing.T) {
+	server := newTestServer(t, &mockDB{}, 1, false)
+	server.FrontendURL = "https://app.example.com"
+	handler := server.HTTPHandler()
+
+	t.Run("mismatched origin on POST is rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/create/secret", nil)
+		req.Header.Set("Origin", "https://evil.com")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("expected 403 for mismatched origin, got %d", w.Code)
+		}
+	})
+
+	t.Run("matching origin on POST is allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/create/secret", nil)
+		req.Header.Set("Origin", "https://app.example.com")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code == http.StatusForbidden {
+			t.Errorf("expected matching origin to pass CSRF check, got 403")
+		}
+	})
+
+	t.Run("GET with mismatched origin is allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/config", nil)
+		req.Header.Set("Origin", "https://evil.com")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code == http.StatusForbidden {
+			t.Errorf("GET should not be subject to CSRF origin check")
+		}
+	})
+
+	t.Run("POST without origin header is allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/create/secret", nil)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code == http.StatusForbidden {
+			t.Errorf("same-origin POST (no Origin header) should not be blocked")
+		}
+	})
+}
+
 // TestConfigHandler_LicensedBranches covers the optional config fields and
 // License.Valid branches of configHandler that the existing TestConfigHandler*
 // tests do not reach: MAX_FILE_SIZE, LOGO_URL, OIDC_ENABLED/REQUIRE_AUTH,


### PR DESCRIPTION

When --frontend-url is set (split-origin deployment), the session cookie uses SameSite=None so browsers attach it on cross-site requests. Without an Origin check, an attacker page can POST to /create/secret or /request using a text/plain form (no preflight) and the cookie rides along.

The CORS middleware now rejects POST/PUT/DELETE requests whose Origin header is present but does not match the configured frontend origin. GET/HEAD/OPTIONS are not affected. When no Origin header is sent (same- origin requests), SameSite=Lax on the cookie is sufficient protection.