### PR TITLE
Wire --force-expiration/FORCE_EXPIRATION flag into Server config

### DIFF
--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -296,7 +296,8 @@ func main() {
 		ThemeCustomLight: viper.GetString("theme-custom-light"),
 		ThemeCustomDark:  viper.GetString("theme-custom-dark"),
 
-		DefaultExpiry: viper.GetString("default-expiry"),
+		DefaultExpiry:   viper.GetString("default-expiry"),
+		ForceExpiration: viper.GetString("force-expiration"),
 	}
 	// Start cleanup goroutine for file store (disk or S3)
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())


### PR DESCRIPTION
The flag was defined and validated at startup but never copied into the server.Server struct, so it had no runtime effect (issue #3206).