### PR TITLE
Use APP_NAME config for footer copyright branding

### DIFF
--- a/website/src/app/App.tsx
+++ b/website/src/app/App.tsx
@@ -173,7 +173,7 @@ export default function App() {
                 </>
               )}
               <span className="text-base-content/70">
-                {APP_NAME ? (
+                {APP_NAME && APP_NAME.trim() ? (
                   <>
                     &copy; {new Date().getFullYear()} {APP_NAME}
                   </>

--- a/website/src/app/App.tsx
+++ b/website/src/app/App.tsx
@@ -44,6 +44,7 @@ export default function App() {
 
   // Whether creation pages must show the login gate instead of their content.
   const needsLogin = REQUIRE_AUTH && !authLoading && !isAuthenticated;
+  const appName = APP_NAME?.trim();
   return (
     <div className="min-h-screen bg-base-200 flex flex-col overflow-x-hidden">
       <button
@@ -173,9 +174,9 @@ export default function App() {
                 </>
               )}
               <span className="text-base-content/70">
-                {APP_NAME && APP_NAME.trim() ? (
+                {appName ? (
                   <>
-                    &copy; {new Date().getFullYear()} {APP_NAME}
+                    &copy; {new Date().getFullYear()} {appName}
                   </>
                 ) : (
                   <>

--- a/website/src/app/App.tsx
+++ b/website/src/app/App.tsx
@@ -24,6 +24,7 @@ export default function App() {
     REQUIRE_AUTH,
     SECRET_REQUESTS,
     READ_RECEIPTS,
+    APP_NAME,
   } = useConfig();
   const { isAuthenticated, loading: authLoading } = useAuth();
   const { t } = useTranslation();
@@ -172,15 +173,23 @@ export default function App() {
                 </>
               )}
               <span className="text-base-content/70">
-                &copy; 2014&ndash;{new Date().getFullYear()}{' '}
-                <a
-                  href="https://yopass.se"
-                  className="text-primary hover:text-primary-focus font-medium transition-colors duration-200 underline decoration-dotted underline-offset-4 hover:decoration-solid"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Yopass
-                </a>
+                {APP_NAME ? (
+                  <>
+                    &copy; {new Date().getFullYear()} {APP_NAME}
+                  </>
+                ) : (
+                  <>
+                    &copy; 2014&ndash;{new Date().getFullYear()}{' '}
+                    <a
+                      href="https://yopass.se"
+                      className="text-primary hover:text-primary-focus font-medium transition-colors duration-200 underline decoration-dotted underline-offset-4 hover:decoration-solid"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Yopass
+                    </a>
+                  </>
+                )}
               </span>
             </div>
           </div>

--- a/website/tests/footer-links.spec.ts
+++ b/website/tests/footer-links.spec.ts
@@ -227,11 +227,14 @@ test.describe('Footer Links', () => {
     await page.waitForLoadState('networkidle');
 
     const footer = page.locator('footer');
-    await expect(footer).toContainText('© 2014');
+    const currentYear = await page.evaluate(() =>
+      new Date().getFullYear().toString(),
+    );
+    await expect(footer).toContainText(`© 2014–${currentYear}`);
     await expect(footer.locator('a[href="https://yopass.se"]')).toBeVisible();
-    await expect(
-      footer.locator('a[href="https://yopass.se"]'),
-    ).toHaveText('Yopass');
+    await expect(footer.locator('a[href="https://yopass.se"]')).toHaveText(
+      'Yopass',
+    );
   });
 
   test('should show custom APP_NAME in footer copyright when configured', async ({
@@ -254,7 +257,9 @@ test.describe('Footer Links', () => {
     await page.waitForLoadState('networkidle');
 
     const footer = page.locator('footer');
-    const currentYear = new Date().getFullYear().toString();
+    const currentYear = await page.evaluate(() =>
+      new Date().getFullYear().toString(),
+    );
     await expect(footer).toContainText(`© ${currentYear} Acme Secrets`);
     await expect(footer).not.toContainText('2014');
     await expect(

--- a/website/tests/footer-links.spec.ts
+++ b/website/tests/footer-links.spec.ts
@@ -207,4 +207,58 @@ test.describe('Footer Links', () => {
     ).not.toBeVisible();
     await expect(page.locator('a:has-text("Imprint")')).not.toBeVisible();
   });
+
+  test('should show default Yopass copyright when APP_NAME is not set', async ({
+    page,
+  }) => {
+    await page.route('**/config', async route => {
+      await route.fulfill({
+        status: 200,
+        json: {
+          DISABLE_UPLOAD: false,
+          PREFETCH_SECRET: true,
+          DISABLE_FEATURES: false,
+          NO_LANGUAGE_SWITCHER: false,
+        },
+      });
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const footer = page.locator('footer');
+    await expect(footer).toContainText('© 2014');
+    await expect(footer.locator('a[href="https://yopass.se"]')).toBeVisible();
+    await expect(
+      footer.locator('a[href="https://yopass.se"]'),
+    ).toHaveText('Yopass');
+  });
+
+  test('should show custom APP_NAME in footer copyright when configured', async ({
+    page,
+  }) => {
+    await page.route('**/config', async route => {
+      await route.fulfill({
+        status: 200,
+        json: {
+          DISABLE_UPLOAD: false,
+          PREFETCH_SECRET: true,
+          DISABLE_FEATURES: false,
+          NO_LANGUAGE_SWITCHER: false,
+          APP_NAME: 'Acme Secrets',
+        },
+      });
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const footer = page.locator('footer');
+    const currentYear = new Date().getFullYear().toString();
+    await expect(footer).toContainText(`© ${currentYear} Acme Secrets`);
+    await expect(footer).not.toContainText('2014');
+    await expect(
+      footer.locator('a[href="https://yopass.se"]'),
+    ).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- When `APP_NAME` is set in `/config`, the footer displays the custom name with the current year instead of the default "Yopass" link and 2014–present range
- Falls back to the existing Yopass-branded footer when `APP_NAME` is not configured
- Adds E2E tests covering both the default and custom branding cases

## Test plan
- [ ] Verify footer shows "© 2014–2026 Yopass" link when `APP_NAME` is not set
- [ ] Verify footer shows "© 2026 Acme Secrets" (no link) when `APP_NAME` is configured
- [ ] Run `cd website && yarn playwright test footer-links`