### PR TITLE
fix(cdk): implement Update method for DynamoDB backend

### DIFF
--- a/deploy/cdk/main.go
+++ b/deploy/cdk/main.go
@@ -322,6 +322,21 @@ func (d *Dynamo) Status(key string) (yopass.Secret, error) {
 	return s, nil
 }
 
+// Update reads the existing secret record, applies fn, and replaces the stored secret.
+func (d *Dynamo) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	s, err := d.Status(key)
+	if err != nil {
+		return err
+	}
+
+	updated, err := fn(s)
+	if err != nil {
+		return err
+	}
+
+	return d.Put(key, updated)
+}
+
 // Dummy health check
 func (d *Dynamo) Health() error {
     return nil


### PR DESCRIPTION
### Summary
Fixes a compilation error in `deploy/cdk/main.go` where the `*Dynamo` struct failed to satisfy the `server.Database` interface due to a missing `Update` method.

### Problem
Building the Lambda binary in `deploy/cdk` currently fails with the following build error:

```text
./main.go:202:9: cannot use &Dynamo{…} (value of type *Dynamo) as server.Database value in return statement: *Dynamo does not implement server.Database (missing method Update)
```

This occurred because the `server.Database` interface requires:

```go
Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error
```

However, the CDK DynamoDB backend implementation in `deploy/cdk/main.go` was missing this method signature.

### Solution
Implemented the `Update` method receiver on `*Dynamo` in `deploy/cdk/main.go`:

1. Fetches the current secret record using `Status(key)`.
2. Applies the provided transformation callback function `fn(secret)`.
3. Stores the updated secret back using `Put(key, updated)`.

### Verification
Validated that `deploy/cdk` now compiles cleanly without interface mismatches:

```bash
cd deploy/cdk
go mod tidy
go build -tags lambda.norpc .
```