### PR TITLE
Remove APP_NAME footer branding

### DIFF
--- a/website/src/app/App.tsx
+++ b/website/src/app/App.tsx
@@ -24,7 +24,6 @@ export default function App() {
     REQUIRE_AUTH,
     SECRET_REQUESTS,
     READ_RECEIPTS,
-    APP_NAME,
   } = useConfig();
   const { isAuthenticated, loading: authLoading } = useAuth();
   const { t } = useTranslation();
@@ -44,7 +43,6 @@ export default function App() {
 
   // Whether creation pages must show the login gate instead of their content.
   const needsLogin = REQUIRE_AUTH && !authLoading && !isAuthenticated;
-  const appName = APP_NAME?.trim();
   return (
     <div className="min-h-screen bg-base-200 flex flex-col overflow-x-hidden">
       <button
@@ -174,23 +172,15 @@ export default function App() {
                 </>
               )}
               <span className="text-base-content/70">
-                {appName ? (
-                  <>
-                    &copy; {new Date().getFullYear()} {appName}
-                  </>
-                ) : (
-                  <>
-                    &copy; 2014&ndash;{new Date().getFullYear()}{' '}
-                    <a
-                      href="https://yopass.se"
-                      className="text-primary hover:text-primary-focus font-medium transition-colors duration-200 underline decoration-dotted underline-offset-4 hover:decoration-solid"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Yopass
-                    </a>
-                  </>
-                )}
+                &copy; 2014&ndash;{new Date().getFullYear()}{' '}
+                <a
+                  href="https://yopass.se"
+                  className="text-primary hover:text-primary-focus font-medium transition-colors duration-200 underline decoration-dotted underline-offset-4 hover:decoration-solid"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Yopass
+                </a>
               </span>
             </div>
           </div>

--- a/website/tests/footer-links.spec.ts
+++ b/website/tests/footer-links.spec.ts
@@ -236,34 +236,4 @@ test.describe('Footer Links', () => {
       'Yopass',
     );
   });
-
-  test('should show custom APP_NAME in footer copyright when configured', async ({
-    page,
-  }) => {
-    await page.route('**/config', async route => {
-      await route.fulfill({
-        status: 200,
-        json: {
-          DISABLE_UPLOAD: false,
-          PREFETCH_SECRET: true,
-          DISABLE_FEATURES: false,
-          NO_LANGUAGE_SWITCHER: false,
-          APP_NAME: 'Acme Secrets',
-        },
-      });
-    });
-
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-
-    const footer = page.locator('footer');
-    const currentYear = await page.evaluate(() =>
-      new Date().getFullYear().toString(),
-    );
-    await expect(footer).toContainText(`© ${currentYear} Acme Secrets`);
-    await expect(footer).not.toContainText('2014');
-    await expect(
-      footer.locator('a[href="https://yopass.se"]'),
-    ).not.toBeVisible();
-  });
 });


### PR DESCRIPTION
## Summary
- Footer always shows `© 2014–{year} Yopass` with yopass.se link, regardless of APP_NAME config
- APP_NAME continues to control navbar title, logo alt text, and browser tab — those are the branding surfaces
- Removed the custom APP_NAME footer E2E test; default Yopass copyright test remains

## Test plan
- [x] `yarn run lint` passes
- [x] `npx playwright test footer-links` — 21 tests pass across chromium/firefox/webkit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TP3SaeUs7qsi5o1MrF3at