### PR TITLE
Allow any CSS custom property in theme-custom-* flags

### DIFF
--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -382,6 +383,11 @@ func main() {
 	logger.Info("Server shut down")
 }
 
+// unsafeCSSVarChars mirrors the frontend's sanitization in
+// website/src/shared/context/ConfigContext.tsx so invalid theme-custom
+// entries fail fast at startup instead of being silently dropped in the UI.
+var unsafeCSSVarChars = regexp.MustCompile(`[;{}<>]`)
+
 // validateFlags checks flag values and cross-flag requirements that need no
 // constructed dependencies, returning an error describing the first problem
 // found. An expired license (verified signature but past expiry) degrades
@@ -421,9 +427,12 @@ func validateFlags(license server.LicenseStatus, logger *zap.Logger) error {
 		if err := json.Unmarshal([]byte(raw), &vars); err != nil {
 			return fmt.Errorf("invalid JSON for --%s: %w", flagName, err)
 		}
-		for k := range vars {
+		for k, v := range vars {
 			if !strings.HasPrefix(k, "--") {
 				return fmt.Errorf("--%s contains invalid CSS variable key %q (must start with --)", flagName, k)
+			}
+			if unsafeCSSVarChars.MatchString(k) || unsafeCSSVarChars.MatchString(v) {
+				return fmt.Errorf("--%s contains invalid CSS variable %q (keys and values must not contain ; { } < >)", flagName, k)
 			}
 		}
 	}

--- a/cmd/yopass-server/main.go
+++ b/cmd/yopass-server/main.go
@@ -422,8 +422,8 @@ func validateFlags(license server.LicenseStatus, logger *zap.Logger) error {
 			return fmt.Errorf("invalid JSON for --%s: %w", flagName, err)
 		}
 		for k := range vars {
-			if !strings.HasPrefix(k, "--color-") {
-				return fmt.Errorf("--%s contains invalid CSS variable key %q (must start with --color-)", flagName, k)
+			if !strings.HasPrefix(k, "--") {
+				return fmt.Errorf("--%s contains invalid CSS variable key %q (must start with --)", flagName, k)
 			}
 		}
 	}

--- a/cmd/yopass-server/startup_test.go
+++ b/cmd/yopass-server/startup_test.go
@@ -74,6 +74,16 @@ func TestValidateFlags(t *testing.T) {
 			flags: map[string]interface{}{"theme-custom-dark": `{"--container-3xl":"82.5rem"}`},
 		},
 		{
+			name:    "custom theme key with unsafe characters",
+			flags:   map[string]interface{}{"theme-custom-dark": `{"--color-primary}{":"red"}`},
+			wantErr: "must not contain",
+		},
+		{
+			name:    "custom theme value with unsafe characters",
+			flags:   map[string]interface{}{"theme-custom-dark": `{"--color-primary":"red;} body{display:none"}`},
+			wantErr: "must not contain",
+		},
+		{
 			name:    "oidc-issuer requires license",
 			flags:   map[string]interface{}{"oidc-issuer": "https://accounts.example.com"},
 			wantErr: "--oidc-issuer is configured but no valid license key",

--- a/cmd/yopass-server/startup_test.go
+++ b/cmd/yopass-server/startup_test.go
@@ -61,13 +61,17 @@ func TestValidateFlags(t *testing.T) {
 			wantErr: "invalid JSON for --theme-custom-light",
 		},
 		{
-			name:    "custom theme non-color variable",
-			flags:   map[string]interface{}{"theme-custom-dark": `{"--font-size":"12px"}`},
-			wantErr: "must start with --color-",
+			name:    "custom theme key without -- prefix",
+			flags:   map[string]interface{}{"theme-custom-dark": `{"font-size":"12px"}`},
+			wantErr: "must start with --",
 		},
 		{
-			name:  "custom theme valid",
+			name:  "custom theme valid color variable",
 			flags: map[string]interface{}{"theme-custom-dark": `{"--color-primary":"red"}`},
+		},
+		{
+			name:  "custom theme valid non-color variable",
+			flags: map[string]interface{}{"theme-custom-dark": `{"--container-3xl":"82.5rem"}`},
 		},
 		{
 			name:    "oidc-issuer requires license",
@@ -75,15 +79,15 @@ func TestValidateFlags(t *testing.T) {
 			wantErr: "--oidc-issuer is configured but no valid license key",
 		},
 		{
-			name:         "oidc-issuer with license",
-			flags:        map[string]interface{}{"oidc-issuer": "https://accounts.example.com"},
+			name:    "oidc-issuer with license",
+			flags:   map[string]interface{}{"oidc-issuer": "https://accounts.example.com"},
 			license: validLicense,
 		},
 		{
-			name:         "require-auth without oidc-issuer",
-			flags:        map[string]interface{}{"require-auth": true},
+			name:    "require-auth without oidc-issuer",
+			flags:   map[string]interface{}{"require-auth": true},
 			license: validLicense,
-			wantErr:      "--require-auth is set but OIDC is not configured",
+			wantErr: "--require-auth is set but OIDC is not configured",
 		},
 		{
 			name: "require-auth without license",
@@ -118,8 +122,8 @@ func TestValidateFlags(t *testing.T) {
 			wantErr: "--audit-log requires a valid license key",
 		},
 		{
-			name:         "audit-log with license",
-			flags:        map[string]interface{}{"audit-log": true},
+			name:    "audit-log with license",
+			flags:   map[string]interface{}{"audit-log": true},
 			license: validLicense,
 		},
 		{

--- a/docs/server-options.md
+++ b/docs/server-options.md
@@ -178,8 +178,8 @@ See [OpenID Connect](./openid-connect) for provider-specific setup and multi-ins
 | `--logo-url` | `LOGO_URL` | — | URL to a custom logo image (e.g. `/mylogo.svg` for a file in the `public/` directory, or an external CDN URL) |
 | `--theme-light` | `THEME_LIGHT` | `emerald` | DaisyUI theme name for light mode |
 | `--theme-dark` | `THEME_DARK` | `dim` | DaisyUI theme name for dark mode |
-| `--theme-custom-light` | `THEME_CUSTOM_LIGHT` | — | JSON object of CSS variables for a fully custom light theme (keys must start with `--color-`) |
-| `--theme-custom-dark` | `THEME_CUSTOM_DARK` | — | JSON object of CSS variables for a fully custom dark theme (keys must start with `--color-`) |
+| `--theme-custom-light` | `THEME_CUSTOM_LIGHT` | — | JSON object of CSS variables for a fully custom light theme (keys must start with `--`; only `--color-*` is officially supported, see [theming docs](./theming.md)) |
+| `--theme-custom-dark` | `THEME_CUSTOM_DARK` | — | JSON object of CSS variables for a fully custom dark theme (keys must start with `--`; only `--color-*` is officially supported, see [theming docs](./theming.md)) |
 
 See [Theming & Branding](./theming) for available theme names and CSS variable examples.
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -41,7 +41,7 @@ Available built-in theme names: `light`, `dark`, `cupcake`, `bumblebee`, `emeral
 
 ### Custom themes
 
-Provide a JSON object of CSS variables to override specific design tokens for each color scheme. Only `--color-*` variables are accepted.
+Provide a JSON object of CSS variables to override specific design tokens for each color scheme. Any valid CSS custom property (starting with `--`) is accepted.
 
 ```bash
 yopass-server \
@@ -153,5 +153,5 @@ services:
 
 ## Notes
 
-- Custom theme variables that do not start with `--color-` are rejected at startup.
+- Custom theme variable keys must start with `--`. Only `--color-*` variables (the DaisyUI design tokens) are officially supported; other CSS custom properties (e.g. `--container-*`, `--spacing-*`) are passed through as-is with no guarantees — they may stop working at any point if Tailwind CSS or DaisyUI rename or remove them in a future release.
 - When any branding flag is set without a `--license-key`, the server starts but the customisation is not applied.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -41,7 +41,7 @@ Available built-in theme names: `light`, `dark`, `cupcake`, `bumblebee`, `emeral
 
 ### Custom themes
 
-Provide a JSON object of CSS variables to override specific design tokens for each color scheme. Any valid CSS custom property (starting with `--`) is accepted.
+Provide a JSON object of CSS variables to override specific design tokens for each color scheme. Keys must start with `--`, and neither keys nor values may contain `; { } < >`. Only `--color-*` variables (the DaisyUI design tokens) are officially supported — see the note below.
 
 ```bash
 yopass-server \
@@ -59,7 +59,7 @@ yopass-server \
   --theme-custom-light '{"--color-primary":"oklch(50% 0.22 142)"}'
 ```
 
-All values must use the `oklch(...)` color format, which is what DaisyUI 4 expects.
+All `--color-*` values must use the `oklch(...)` color format, which is what DaisyUI 4 expects. Other variable types (e.g. `--container-*`) use whatever unit is appropriate for that property, such as `rem`.
 
 Use the [DaisyUI theme generator](https://daisyui.com/theme-generator/) to interactively build and preview a custom theme, then copy the resulting CSS variable values and pass them as a JSON object to the `--theme-custom-light` or `--theme-custom-dark` flags.
 
@@ -153,5 +153,5 @@ services:
 
 ## Notes
 
-- Custom theme variable keys must start with `--`. Only `--color-*` variables (the DaisyUI design tokens) are officially supported; other CSS custom properties (e.g. `--container-*`, `--spacing-*`) are passed through as-is with no guarantees — they may stop working at any point if Tailwind CSS or DaisyUI rename or remove them in a future release.
+- Custom theme variable keys must start with `--`, and keys/values must not contain `; { } < >`; entries that violate either rule are rejected at startup. Only `--color-*` variables (the DaisyUI design tokens) are officially supported; other CSS custom properties (e.g. `--container-*`, `--spacing-*`) are passed through as-is with no guarantees — they may stop working at any point if Tailwind CSS or DaisyUI rename or remove them in a future release.
 - When any branding flag is set without a `--license-key`, the server starts but the customisation is not applied.


### PR DESCRIPTION
## Summary
- Relaxes the `--theme-custom-light` / `--theme-custom-dark` validation to accept any `--`-prefixed CSS variable, not just `--color-*`
- Lets users override layout-related design tokens (e.g. `--container-3xl`) without patching the binary, since Docker deployments have no easy way to inject custom CSS
- Docs updated with a disclaimer: only `--color-*` is officially supported, other variables are passed through with no guarantees and may break on future Tailwind/DaisyUI updates

Closes #3832

## Test plan
- [x] `go test ./cmd/yopass-server/...` passes
- [x] Added test case for a valid non-color variable (`--container-3xl`)
- [x] Added test case confirming a key without `--` prefix is still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFMGJMi1VAbo7GQ7dYT3hx