### PR TITLE
polish(microsite): address landing page critique findings

### DIFF
--- a/microsite/src/components/EncryptionTerminal.tsx
+++ b/microsite/src/components/EncryptionTerminal.tsx
@@ -93,7 +93,7 @@ export default function EncryptionTerminal(): React.ReactElement {
 
   return (
     <div
-      className="bg-gray-950 rounded-2xl overflow-hidden select-none animate-float terminal-depth"
+      className="bg-gray-950 rounded-2xl overflow-hidden select-none terminal-depth"
       aria-hidden="true"
     >
       {/* Window chrome */}

--- a/microsite/src/css/custom.css
+++ b/microsite/src/css/custom.css
@@ -184,18 +184,6 @@ h1, h2, h3 {
 .delay-300 { animation-delay: 0.3s; }
 .delay-400 { animation-delay: 0.4s; }
 
-/* ─── Scroll reveal ─── */
-.reveal {
-  opacity: 0;
-  transform: translateY(24px);
-  transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.reveal.visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
 /* ─── Step connector ─── */
 .step-connector {
   background: linear-gradient(90deg, #009643, #06637c, #1100e9);
@@ -297,11 +285,6 @@ h1, h2, h3 {
   }
   .animate-float {
     animation: none;
-  }
-  .reveal {
-    opacity: 1;
-    transform: none;
-    transition: none;
   }
   .feature-card,
   .pricing-card,

--- a/microsite/src/pages/index.tsx
+++ b/microsite/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import EncryptionTerminal from '../components/EncryptionTerminal';
@@ -6,24 +6,6 @@ import CheckoutModal from '../components/CheckoutModal';
 
 export default function Home(): React.ReactElement {
   const [checkoutOpen, setCheckoutOpen] = useState(false);
-
-  useEffect(() => {
-    const reveals = document.querySelectorAll<HTMLElement>('.reveal');
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry, i) => {
-          if (entry.isIntersecting) {
-            (entry.target as HTMLElement).style.transitionDelay = `${i * 0.08}s`;
-            entry.target.classList.add('visible');
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      { threshold: 0.12, rootMargin: '0px 0px -40px 0px' }
-    );
-    reveals.forEach(el => observer.observe(el));
-    return () => observer.disconnect();
-  }, []);
 
   return (
     <Layout title="Share Secrets Securely | End-to-End Encrypted Secret Sharing" noFooter>
@@ -74,7 +56,7 @@ export default function Home(): React.ReactElement {
                 Share Secrets<br />
                 <span className="text-brand-green">Securely</span>
               </h1>
-              <p className="text-xl text-gray-500 leading-relaxed max-w-lg mb-10 animate-fade-up delay-200">
+              <p className="text-xl text-gray-600 leading-relaxed max-w-lg mb-10 animate-fade-up delay-200">
                 Stop sharing passwords in Slack, email, and ticket systems. Yopass encrypts secrets in your browser and generates one-time links that auto-expire.
               </p>
 
@@ -98,7 +80,7 @@ export default function Home(): React.ReactElement {
               </div>
 
               <div className="animate-fade-up delay-400">
-                <p className="text-xs font-medium text-gray-400 uppercase tracking-wider">Trusted by engineers at</p>
+                <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">Trusted by engineers at</p>
                 <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mt-2.5">
                   <span className="text-sm font-bold text-gray-500">Spotify</span>
                   <span className="w-1 h-1 rounded-full bg-gray-300" />
@@ -110,7 +92,7 @@ export default function Home(): React.ReactElement {
             </div>
 
             {/* Right: terminal animation */}
-            <div className="hidden md:block animate-fade-in delay-300">
+            <div className="mt-8 md:mt-0 animate-fade-in delay-300">
               <EncryptionTerminal />
             </div>
 
@@ -121,22 +103,22 @@ export default function Home(): React.ReactElement {
       {/* ── PROBLEM + SOLUTION (compressed) ── */}
       <section className="py-20 md:py-28 bg-white relative">
         <div className="max-w-6xl mx-auto px-6">
-          <div className="reveal max-w-3xl mx-auto text-center mb-14 md:mb-16">
+          <div className="max-w-3xl mx-auto text-center mb-14 md:mb-16">
             <p className="code-accent text-brand-teal mb-4">The problem</p>
             <h2 className="text-3xl md:text-5xl font-bold tracking-tight mb-5">
               Secrets don't belong in your chat history
             </h2>
-            <p className="text-gray-500 text-lg leading-relaxed">
+            <p className="text-gray-600 text-lg leading-relaxed">
               Passwords and API keys shared over Slack, email, and tickets sit in plaintext — searchable forever, readable by anyone with access. Yopass replaces that with three simple steps.
             </p>
           </div>
 
-          <div className="reveal grid md:grid-cols-3 gap-6">
+          <div className="grid md:grid-cols-3 gap-6">
             {[
               {
                 n: '01', title: 'Encrypt',
                 icon: <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />,
-                desc: 'Type or paste your secret. It\'s encrypted in your browser with OpenPGP before anything leaves your machine.',
+                desc: 'Type or paste your secret. It\'s encrypted in your browser before anything leaves your machine.',
               },
               {
                 n: '02', title: 'Share',
@@ -154,7 +136,7 @@ export default function Home(): React.ReactElement {
                   <svg className="w-5 h-5 text-brand-green" fill="none" stroke="currentColor" viewBox="0 0 24 24">{icon}</svg>
                 </div>
                 <h3 className="font-bold text-lg mb-1.5">{n}. {title}</h3>
-                <p className="text-sm text-gray-500 leading-relaxed">{desc}</p>
+                <p className="text-sm text-gray-600 leading-relaxed">{desc}</p>
               </div>
             ))}
           </div>
@@ -164,19 +146,19 @@ export default function Home(): React.ReactElement {
       {/* ── FOR BUSINESS ── */}
       <section className="py-20 md:py-28 dark-section">
         <div className="max-w-6xl mx-auto px-6">
-          <div className="reveal flex flex-col md:flex-row md:items-end justify-between gap-6 mb-12 md:mb-16">
+          <div className="flex flex-col md:flex-row md:items-end justify-between gap-6 mb-12 md:mb-16">
             <div className="max-w-2xl">
               <p className="code-accent text-emerald-400 mb-4">For teams &amp; business</p>
               <h2 className="text-3xl md:text-5xl font-bold tracking-tight text-white/95">
                 Advanced security governance
               </h2>
             </div>
-            <p className="text-white/55 text-lg max-w-sm">
+            <p className="text-white/70 text-lg max-w-sm">
               A clear audit trail and secure secret workflows across your entire organization — unlocked with a business license.
             </p>
           </div>
 
-          <div className="reveal grid md:grid-cols-12 gap-6">
+          <div className="grid md:grid-cols-12 gap-6">
             {/* Secret Requests — wide */}
             <a
               href="/docs/secret-requests"
@@ -187,7 +169,7 @@ export default function Home(): React.ReactElement {
                   <svg className="w-5 h-5 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" /></svg>
                 </div>
                 <h3 className="text-xl font-bold mb-2 text-white/95">Secret Requests</h3>
-                <p className="text-sm text-white/55 leading-relaxed">
+                <p className="text-sm text-white/70 leading-relaxed">
                   Receive credentials securely from vendors or clients who don't use Yopass. Send a request link, they upload the secret, and you receive it encrypted.
                 </p>
               </div>
@@ -203,7 +185,7 @@ export default function Home(): React.ReactElement {
                 <svg className="w-5 h-5 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" /></svg>
               </div>
               <h3 className="text-xl font-bold mb-2 text-white/95">Read Receipts</h3>
-              <p className="text-sm text-white/55 leading-relaxed">
+              <p className="text-sm text-white/70 leading-relaxed">
                 Know exactly when a secret is opened. Get notified by email or webhook the moment a one-time link is decrypted.
               </p>
             </a>
@@ -217,7 +199,7 @@ export default function Home(): React.ReactElement {
                 <svg className="w-5 h-5 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
               </div>
               <h3 className="text-xl font-bold mb-2 text-white/95">Webhooks</h3>
-              <p className="text-sm text-white/55 leading-relaxed">
+              <p className="text-sm text-white/70 leading-relaxed">
                 Push security events into your SOC or dev workflows. Trigger automated actions when secrets are created, requested, or accessed.
               </p>
             </a>
@@ -231,7 +213,7 @@ export default function Home(): React.ReactElement {
                 <svg className="w-5 h-5 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" /></svg>
               </div>
               <h3 className="text-xl font-bold mb-2 text-white/95">OpenID Connect Sign-In</h3>
-              <p className="text-sm text-white/55 leading-relaxed">
+              <p className="text-sm text-white/70 leading-relaxed">
                 Put secret creation behind single sign-on. Require users to authenticate through your OpenID Connect provider before sharing.
               </p>
             </a>
@@ -245,7 +227,7 @@ export default function Home(): React.ReactElement {
                 <svg className="w-5 h-5 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7l2 2 4-4" /></svg>
               </div>
               <h3 className="text-xl font-bold mb-2 text-white/95">Audit Logs</h3>
-              <p className="text-sm text-white/55 leading-relaxed mb-5">
+              <p className="text-sm text-white/70 leading-relaxed mb-5">
                 Keep a non-repudiable record of sharing activity for compliance — who requested what and when, without ever exposing the secrets themselves.
               </p>
               <div className="mt-auto font-mono text-xs rounded-xl bg-black/25 border border-white/10 p-4 text-emerald-300/90">
@@ -260,74 +242,30 @@ export default function Home(): React.ReactElement {
         </div>
       </section>
 
-      {/* ── BUILT FOR SECURITY ── */}
-      <section className="py-20 md:py-28 relative">
-        <div className="absolute inset-0 mesh-bg opacity-70" />
-        <div className="relative max-w-6xl mx-auto px-6">
-          <div className="reveal text-center mb-14 md:mb-16">
-            <p className="code-accent text-brand-teal mb-4">Built for security</p>
-            <h2 className="text-3xl md:text-5xl font-bold tracking-tight mb-4">Simple enough to actually use</h2>
-            <p className="text-gray-500 text-lg max-w-2xl mx-auto">
-              Designed so that following best security practices becomes the path of least resistance.
-            </p>
-          </div>
-
-          <div className="reveal grid md:grid-cols-3 gap-8 md:gap-10">
-            {[
-              {
-                title: 'End-to-End Encryption',
-                desc: 'Encryption and decryption happen locally in your browser. The server never sees your plaintext data.',
-                icon: <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />,
-              },
-              {
-                title: 'No Accounts Needed',
-                desc: 'No sign-ups, no tracking, no cookies. Only the encrypted secret is stored — nothing else.',
-                icon: <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />,
-              },
-              {
-                title: 'Open Source',
-                desc: 'Audit the code, contribute features, or self-host with full confidence on your own infrastructure.',
-                icon: <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />,
-              },
-            ].map(({ title, desc, icon }) => (
-              <div key={title} className="flex gap-4">
-                <div className="w-11 h-11 shrink-0 rounded-xl bg-tint-green flex items-center justify-center">
-                  <svg className="w-5 h-5 text-brand-green" fill="none" stroke="currentColor" viewBox="0 0 24 24">{icon}</svg>
-                </div>
-                <div>
-                  <h3 className="font-bold text-lg mb-1.5">{title}</h3>
-                  <p className="text-sm text-gray-500 leading-relaxed">{desc}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       {/* ── PRICING ── */}
-      <section id="pricing" className="py-20 md:py-28 bg-[#eaf6fb]">
+      <section id="pricing" className="py-20 md:py-28 bg-tint-blue">
         <div className="max-w-6xl mx-auto px-6">
-          <div className="reveal text-center mb-16">
+          <div className="text-center mb-16">
             <p className="code-accent text-brand-teal mb-4">Pricing</p>
             <h2 className="text-3xl md:text-5xl font-bold tracking-tight mb-4">Free to start. Scale when ready.</h2>
-            <p className="text-gray-500 text-lg max-w-xl mx-auto">
+            <p className="text-gray-600 text-lg max-w-xl mx-auto">
               Yopass is open source and free to self-host, always. The business license adds branding and higher limits — still running on your own infrastructure, because that's what makes it truly secure.
             </p>
           </div>
 
-          <div className="reveal grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
+          <div className="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
             {/* Open Source */}
             <div className="pricing-card glass-card rounded-2xl p-8 flex flex-col">
               <div className="mb-6">
                 <h3 className="text-lg font-bold mb-1">Open Source</h3>
                 <div className="flex items-baseline gap-1">
                   <span className="text-4xl font-bold tracking-tight">Free</span>
-                  <span className="text-gray-400 text-sm">self-hosted, forever</span>
+                  <span className="text-gray-500 text-sm">self-hosted, forever</span>
                 </div>
               </div>
 
               <ul className="space-y-3 mb-8 flex-1">
-                {['End-to-end encryption', 'One-time secret links', 'File upload support', 'Configurable expiration (1h / 1d / 1w)', 'Redis or Memcached backend', 'Docker + Kubernetes deployment', 'Community support via GitHub'].map(item => (
+                {['End-to-end encryption', 'One-time secret links', 'File upload support', 'Configurable expiration (1h / 1d / 1w)', 'Localization', 'Redis or Memcached backend', 'Docker + Kubernetes deployment', 'Community support via GitHub'].map(item => (
                   <li key={item} className="flex items-start gap-3 text-sm text-gray-600">
                     <svg className="w-5 h-5 text-brand-green shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
                     {item}
@@ -356,7 +294,7 @@ export default function Home(): React.ReactElement {
                   <h3 className="text-lg font-bold mb-1">Business License</h3>
                   <div className="flex items-baseline gap-1">
                     <span className="text-4xl font-bold tracking-tight text-brand-blue">€149</span>
-                    <span className="text-gray-400 text-sm">/ year · self-hosted</span>
+                    <span className="text-gray-500 text-sm">/ year · self-hosted</span>
                   </div>
                 </div>
 
@@ -397,7 +335,7 @@ export default function Home(): React.ReactElement {
           <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-8">
             <div>
               <img src="/logo/Yopass horizontal.svg" alt="Yopass" className="h-6 mb-3" width={102} height={24} />
-              <p className="text-sm text-gray-400">Created by Johan Haals · © {new Date().getFullYear()} Yopass</p>
+              <p className="text-sm text-gray-500">Created by Johan Haals · © {new Date().getFullYear()} Yopass</p>
             </div>
             <div className="flex flex-wrap items-center gap-6">
               {[


### PR DESCRIPTION
Remove redundant "Built for Security" section that restated the hero's message without advancing the narrative toward pricing. Fix scroll reveal animations that created blank white voids during fast scrolling by removing the IntersectionObserver system entirely. Show the EncryptionTerminal on mobile (was hidden via md:block). Improve color contrast for WCAG AA compliance across secondary text, dark section copy, and footer. Simplify copy by removing "with OpenPGP" jargon from the three-step section. Use the bg-tint-blue token instead of a one-off hex value for pricing background. Remove decorative float animation from the terminal component.