### PR TITLE
Fix DynamoDB one-time claims, expiration, and atomic updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,17 @@ jobs:
         working-directory: deploy/cdk
         env:
           DYNAMODB_ENDPOINT: http://localhost:8000
-        run: go test . -race
+        run: |
+          for i in {1..30}; do
+            if nc -z -w 1 localhost 8000; then
+              go test . -race
+              exit $?
+            fi
+            echo 'Waiting for DynamoDB Local'
+            sleep 1
+          done
+          echo 'DynamoDB Local did not become ready' >&2
+          exit 1
 
       - name: codecov upload
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ jobs:
         image: memcached
         ports:
           - 11211:11211
+      dynamodb:
+        image: amazon/dynamodb-local:3.3.0
+        ports:
+          - 8000:8000
     env:
       MEMCACHED: localhost:11211
       REDIS_URL: "redis://localhost:6379/0"
@@ -37,6 +41,8 @@ jobs:
 
       - name: Go Test (CDK)
         working-directory: deploy/cdk
+        env:
+          DYNAMODB_ENDPOINT: http://localhost:8000
         run: go test . -race
 
       - name: codecov upload

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,12 +45,12 @@ jobs:
           DYNAMODB_ENDPOINT: http://localhost:8000
         run: |
           for i in {1..30}; do
-            if nc -z -w 1 localhost 8000; then
-              go test . -race
-              exit $?
-            fi
-            echo 'Waiting for DynamoDB Local'
-            sleep 1
+          if nc -z -w 1 localhost 8000; then
+          go test . -race
+          exit $?
+          fi
+          echo 'Waiting for DynamoDB Local'
+          sleep 1
           done
           echo 'DynamoDB Local did not become ready' >&2
           exit 1

--- a/deploy/cdk/README.md
+++ b/deploy/cdk/README.md
@@ -53,6 +53,12 @@ Existing records without a revision are supported and receive one on their
 first conditional update. Records with missing or invalid TTL metadata are
 treated as unavailable.
 
+`Dynamo.Update` caps the returned secret's expiration at the record's existing
+absolute expiry. Updates can shorten retention but cannot extend it, including
+time spent processing the mutation. This is stricter than Redis and Memcached,
+which apply the returned `Expiration` as a fresh TTL. Callers must not rely on
+`Database.Update` to extend retention when using this adapter.
+
 ### CDK commands
 
 * `npm run build`   compile typescript to js

--- a/deploy/cdk/README.md
+++ b/deploy/cdk/README.md
@@ -32,6 +32,29 @@ The `cdk.json` file tells the CDK Toolkit how to execute your app.
 
 ## Useful commands
 
+### DynamoDB security regression tests
+
+Run DynamoDB Local, then run the adapter and HTTP integration tests:
+
+```sh
+docker run --rm -p 127.0.0.1:8000:8000 amazon/dynamodb-local:3.3.0
+# In another terminal, from deploy/cdk:
+DYNAMODB_ENDPOINT=http://localhost:8000 go test . -race
+```
+
+The tests use dummy credentials and temporary tables. They cover exclusive
+one-time claims, expiration before physical TTL cleanup, and concurrent request
+updates and revocation. Without `DYNAMODB_ENDPOINT` these integration tests skip;
+CI supplies it. Use a dedicated local database for tests.
+
+Deploy all Lambda instances with the updated adapter before relying on these
+guarantees: older instances still use unconditional writes and deletion claims.
+Existing records without a revision are supported and receive one on their
+first conditional update. Records with missing or invalid TTL metadata are
+treated as unavailable.
+
+### CDK commands
+
 * `npm run build`   compile typescript to js
 * `npm run watch`   watch for changes and compile
 * `npm run test`    perform the jest unit tests

--- a/deploy/cdk/dynamo.go
+++ b/deploy/cdk/dynamo.go
@@ -131,6 +131,8 @@ func (d *Dynamo) Put(key string, s yopass.Secret) error {
 
 // Update implements the Database CAS contract across Lambda instances. Existing
 // records without a revision acquire one on their first conditional update.
+// Unlike Redis/Memcached, this adapter caps the returned secret's expiration at
+// the original absolute expiry. Updates may shorten retention, never extend it.
 func (d *Dynamo) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
 	const retries = 5
 	for attempt := 0; attempt < retries; attempt++ {

--- a/deploy/cdk/dynamo.go
+++ b/deploy/cdk/dynamo.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/jhaals/yopass/pkg/server"
+	"github.com/jhaals/yopass/pkg/yopass"
+)
+
+type dynamoClient interface {
+	GetItem(*dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error)
+	PutItem(*dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error)
+	DeleteItem(*dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error)
+}
+
+type Dynamo struct {
+	tableName string
+	svc       dynamoClient
+}
+
+func NewDynamo(tableName string) server.Database {
+	sess := session.Must(session.NewSession())
+	return &Dynamo{tableName: tableName, svc: dynamodb.New(sess)}
+}
+
+func dynamoKey(key string) map[string]*dynamodb.AttributeValue {
+	return map[string]*dynamodb.AttributeValue{"id": {S: aws.String(key)}}
+}
+
+// read rejects expired records even while DynamoDB's asynchronous TTL cleanup
+// still retains them. Strong reads also avoid observing pre-update state.
+func (d *Dynamo) read(key string) (map[string]*dynamodb.AttributeValue, yopass.Secret, error) {
+	result, err := d.svc.GetItem(&dynamodb.GetItemInput{
+		Key: dynamoKey(key), TableName: aws.String(d.tableName), ConsistentRead: aws.Bool(true),
+	})
+	if err != nil {
+		return nil, yopass.Secret{}, err
+	}
+	item := result.Item
+	ttl := item["ttl"]
+	if ttl == nil || ttl.N == nil {
+		return nil, yopass.Secret{}, server.ErrKeyNotFound
+	}
+	expires, err := strconv.ParseInt(*ttl.N, 10, 64)
+	now := time.Now().Unix()
+	if err != nil || expires <= now || expires > now+math.MaxInt32 {
+		return nil, yopass.Secret{}, server.ErrKeyNotFound
+	}
+	s := yopass.Secret{Expiration: int32(expires - now)}
+	if v := item["secret"]; v != nil {
+		s.Message = aws.StringValue(v.S)
+	}
+	if v := item["one_time"]; v != nil {
+		s.OneTime = aws.BoolValue(v.BOOL)
+	}
+	if v := item["require_auth"]; v != nil {
+		s.RequireAuth = aws.BoolValue(v.BOOL)
+	}
+	return item, s, nil
+}
+
+func (d *Dynamo) Status(key string) (yopass.Secret, error) {
+	_, s, err := d.read(key)
+	return s, err
+}
+
+func (d *Dynamo) Get(key string) (yopass.Secret, error) {
+	s, err := d.Status(key)
+	if err != nil {
+		return yopass.Secret{}, err
+	}
+	if s.OneTime {
+		deleted, err := d.Delete(key)
+		if err != nil {
+			return yopass.Secret{}, err
+		}
+		if !deleted {
+			return yopass.Secret{}, server.ErrKeyNotFound
+		}
+	}
+	return s, nil
+}
+
+// An existence condition makes deletion an exclusive one-time claim. An absent
+// item must return false to the API handlers, not an unconditional-delete success.
+func (d *Dynamo) Delete(key string) (bool, error) {
+	result, err := d.svc.DeleteItem(&dynamodb.DeleteItemInput{
+		Key: dynamoKey(key), TableName: aws.String(d.tableName), ReturnValues: aws.String(dynamodb.ReturnValueAllOld),
+		ConditionExpression: aws.String("attribute_exists(id)"),
+	})
+	if err != nil {
+		if conditionalCheckFailed(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return len(result.Attributes) > 0, nil
+}
+
+func dynamoItem(key string, s yopass.Secret) (map[string]*dynamodb.AttributeValue, error) {
+	// A fresh revision on every write prevents ABA conflicts, including records
+	// deleted and recreated while an update is in flight.
+	revision, err := yopass.GenerateID()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]*dynamodb.AttributeValue{
+		"id": {S: aws.String(key)}, "secret": {S: aws.String(s.Message)},
+		"one_time": {BOOL: aws.Bool(s.OneTime)}, "require_auth": {BOOL: aws.Bool(s.RequireAuth)},
+		"ttl":      {N: aws.String(strconv.FormatInt(time.Now().Unix()+int64(s.Expiration), 10))},
+		"revision": {S: aws.String(revision)},
+	}, nil
+}
+
+func (d *Dynamo) Put(key string, s yopass.Secret) error {
+	item, err := dynamoItem(key, s)
+	if err != nil {
+		return err
+	}
+	_, err = d.svc.PutItem(&dynamodb.PutItemInput{TableName: aws.String(d.tableName), Item: item})
+	return err
+}
+
+// Update implements the Database CAS contract across Lambda instances. Existing
+// records without a revision acquire one on their first conditional update.
+func (d *Dynamo) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
+	const retries = 5
+	for attempt := 0; attempt < retries; attempt++ {
+		old, s, err := d.read(key)
+		if err != nil {
+			return err
+		}
+		updated, err := fn(s)
+		if err != nil {
+			return err
+		}
+		item, err := dynamoItem(key, updated)
+		if err != nil {
+			return err
+		}
+		// Mutation processing time must never extend the original lifetime.
+		oldExpiry, _ := strconv.ParseInt(*old["ttl"].N, 10, 64)
+		newExpiry, _ := strconv.ParseInt(*item["ttl"].N, 10, 64)
+		if newExpiry > oldExpiry {
+			item["ttl"] = old["ttl"]
+		}
+		values := map[string]*dynamodb.AttributeValue{
+			":now": {N: aws.String(strconv.FormatInt(time.Now().Unix(), 10))},
+		}
+		condition := "attribute_exists(id) AND #ttl > :now AND attribute_not_exists(revision)"
+		if revision := old["revision"]; revision != nil {
+			condition = "attribute_exists(id) AND #ttl > :now AND revision = :revision"
+			values[":revision"] = revision
+		}
+		_, err = d.svc.PutItem(&dynamodb.PutItemInput{
+			TableName: aws.String(d.tableName), Item: item,
+			ConditionExpression:       aws.String(condition),
+			ExpressionAttributeNames:  map[string]*string{"#ttl": aws.String("ttl")},
+			ExpressionAttributeValues: values,
+		})
+		if err == nil {
+			return nil
+		}
+		if !conditionalCheckFailed(err) {
+			return err
+		}
+	}
+	return fmt.Errorf("DynamoDB update contention exceeded %d attempts", retries)
+}
+
+func conditionalCheckFailed(err error) bool {
+	var apiErr awserr.Error
+	return errors.As(err, &apiErr) && apiErr.Code() == dynamodb.ErrCodeConditionalCheckFailedException
+}
+
+func (d *Dynamo) Health() error { return nil }

--- a/deploy/cdk/dynamo_test.go
+++ b/deploy/cdk/dynamo_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/jhaals/yopass/pkg/server"
@@ -55,6 +57,13 @@ func testDynamo(t *testing.T) (*Dynamo, *dynamodb.DynamoDB) {
 			t.Error(err)
 		}
 	})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := svc.WaitUntilTableExistsWithContext(ctx, &dynamodb.DescribeTableInput{
+		TableName: aws.String(table),
+	}, request.WithWaiterDelay(request.ConstantWaiterDelay(time.Second))); err != nil {
+		t.Fatalf("wait for test table to become ACTIVE: %v", err)
+	}
 	return &Dynamo{tableName: table, svc: svc}, svc
 }
 

--- a/deploy/cdk/dynamo_test.go
+++ b/deploy/cdk/dynamo_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/jhaals/yopass/pkg/server"
+	"github.com/jhaals/yopass/pkg/yopass"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+)
+
+// Use DynamoDB Local so conditions, missing-item deletion, and concurrent
+// writes are evaluated by DynamoDB rather than reimplemented in a test fake.
+func testDynamo(t *testing.T) (*Dynamo, *dynamodb.DynamoDB) {
+	t.Helper()
+	endpoint := os.Getenv("DYNAMODB_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("set DYNAMODB_ENDPOINT to run DynamoDB Local integration tests")
+	}
+	svc := dynamodb.New(session.Must(session.NewSession(&aws.Config{
+		Endpoint: aws.String(endpoint), Region: aws.String("us-east-1"),
+		Credentials: credentials.NewStaticCredentials("local", "local", ""),
+		HTTPClient:  &http.Client{Timeout: 10 * time.Second}, MaxRetries: aws.Int(0),
+	})))
+	id, err := yopass.GenerateID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	table := "security-" + id
+	_, err = svc.CreateTable(&dynamodb.CreateTableInput{
+		TableName: aws.String(table), BillingMode: aws.String("PAY_PER_REQUEST"),
+		AttributeDefinitions: []*dynamodb.AttributeDefinition{{AttributeName: aws.String("id"), AttributeType: aws.String("S")}},
+		KeySchema:            []*dynamodb.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: aws.String("HASH")}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if _, err := svc.DeleteTable(&dynamodb.DeleteTableInput{TableName: aws.String(table)}); err != nil {
+			t.Error(err)
+		}
+	})
+	return &Dynamo{tableName: table, svc: svc}, svc
+}
+
+// Hold the first two reads of key until both callers have the same snapshot.
+// Separate Dynamo instances using this client model independent Lambda workers.
+type simultaneousReads struct {
+	dynamoClient
+	key   string
+	reads atomic.Int32
+	ready chan struct{}
+}
+
+func (c *simultaneousReads) GetItem(in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+	out, err := c.dynamoClient.GetItem(in)
+	if aws.StringValue(in.Key["id"].S) == c.key {
+		switch c.reads.Add(1) {
+		case 1:
+			select {
+			case <-c.ready:
+			case <-time.After(10 * time.Second):
+				return nil, errors.New("concurrent read did not arrive")
+			}
+		case 2:
+			close(c.ready)
+		}
+	}
+	return out, err
+}
+
+func TestDynamoOneTimeHTTP(t *testing.T) {
+	for _, kind := range []string{"secret", "file", "request"} {
+		t.Run(kind, func(t *testing.T) {
+			db, svc := testDynamo(t)
+			id := "12345678-1234-1234-1234-123456789012"
+			key, path := id, "/secret/"+id
+			secret := yopass.Secret{Message: "ciphertext", OneTime: true, Expiration: 3600}
+			switch kind {
+			case "file":
+				key, path = "stream:"+id, "/file/"+id
+				if err := db.Put("filedata:"+id, yopass.Secret{Message: "Y2lwaGVydGV4dA==", Expiration: 3600}); err != nil {
+					t.Fatal(err)
+				}
+			case "request":
+				key, path = "request/"+id, "/request/"+id+"/secret"
+				hash := sha256.Sum256([]byte("management-token"))
+				data, _ := json.Marshal(server.SecretRequest{
+					TokenHash: hex.EncodeToString(hash[:]), State: server.RequestStateFulfilled,
+					Secret: "ciphertext", ExpiresAt: time.Now().Unix() + 3600,
+				})
+				secret.Message = string(data)
+			}
+			if err := db.Put(key, secret); err != nil {
+				t.Fatal(err)
+			}
+			barrier := &simultaneousReads{dynamoClient: svc, key: key, ready: make(chan struct{})}
+			results := make(chan int, 2)
+			for range 2 {
+				y := &server.Server{
+					DB: &Dynamo{tableName: db.tableName, svc: barrier}, Logger: zap.NewNop(),
+					Registry: prometheus.NewRegistry(), License: server.LicenseStatus{Valid: true, ExpiresAt: time.Now().Add(time.Hour)},
+				}
+				handler := y.HTTPHandler()
+				go func() {
+					r := httptest.NewRequest(http.MethodGet, path, nil)
+					r.Header.Set("X-Yopass-Request-Token", "management-token")
+					w := httptest.NewRecorder()
+					handler.ServeHTTP(w, r)
+					results <- w.Code
+				}()
+			}
+			a, b := <-results, <-results
+			if !((a == 200 && b == 404) || (a == 404 && b == 200)) {
+				t.Fatalf("one-time responses = %d, %d; want one 200 and one 404", a, b)
+			}
+			if deleted, err := db.Delete(key); deleted || err != nil {
+				t.Fatalf("missing delete = %v, %v", deleted, err)
+			}
+		})
+	}
+}
+
+func TestDynamoExpiration(t *testing.T) {
+	db, svc := testDynamo(t)
+	for _, ttl := range []string{"missing", "wrong-type", "1.5", "9223372036854775807", strconv.FormatInt(time.Now().Unix()-60, 10), strconv.FormatInt(time.Now().Unix(), 10)} {
+		for _, prefix := range []string{"", "stream:", "filedata:"} {
+			key := prefix + "expired"
+			item, err := dynamoItem(key, yopass.Secret{Message: "ciphertext", Expiration: 3600})
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch ttl {
+			case "missing":
+				delete(item, "ttl")
+			case "wrong-type":
+				item["ttl"] = &dynamodb.AttributeValue{S: aws.String(ttl)}
+			default:
+				item["ttl"] = &dynamodb.AttributeValue{N: aws.String(ttl)}
+			}
+			if _, err := svc.PutItem(&dynamodb.PutItemInput{TableName: aws.String(db.tableName), Item: item}); err != nil {
+				t.Fatal(err)
+			}
+			for _, read := range []func(string) (yopass.Secret, error){db.Get, db.Status} {
+				if s, err := read(key); !errors.Is(err, server.ErrKeyNotFound) || s.Message != "" {
+					t.Fatalf("ttl %s: %v, %v", ttl, s, err)
+				}
+			}
+			called := false
+			err = db.Update(key, func(s yopass.Secret) (yopass.Secret, error) { called = true; return s, nil })
+			if called || !errors.Is(err, server.ErrKeyNotFound) {
+				t.Fatalf("expired update = %v, called=%v", err, called)
+			}
+		}
+	}
+	if err := db.Put("live", yopass.Secret{Message: "ciphertext", Expiration: 3600, RequireAuth: true}); err != nil {
+		t.Fatal(err)
+	}
+	if s, err := db.Get("live"); err != nil || s.Message != "ciphertext" || !s.RequireAuth || s.Expiration <= 0 {
+		t.Fatalf("live read = %+v, %v", s, err)
+	}
+}
+
+func TestDynamoUpdateConcurrentFulfillment(t *testing.T) {
+	for _, legacy := range []bool{false, true} {
+		t.Run(fmt.Sprintf("legacy=%v", legacy), func(t *testing.T) {
+			db, svc := testDynamo(t)
+			item, err := dynamoItem("request", yopass.Secret{Message: "pending", Expiration: 3600})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if legacy {
+				delete(item, "revision")
+			}
+			if _, err := svc.PutItem(&dynamodb.PutItemInput{TableName: aws.String(db.tableName), Item: item}); err != nil {
+				t.Fatal(err)
+			}
+			barrier := &simultaneousReads{dynamoClient: svc, key: "request", ready: make(chan struct{})}
+			results := make(chan error, 2)
+			alreadyFulfilled := errors.New("already fulfilled")
+			for range 2 {
+				worker := &Dynamo{tableName: db.tableName, svc: barrier}
+				go func() {
+					results <- worker.Update("request", func(s yopass.Secret) (yopass.Secret, error) {
+						if s.Message != "pending" {
+							return s, alreadyFulfilled
+						}
+						s.Message = "fulfilled"
+						return s, nil
+					})
+				}()
+			}
+			a, b := <-results, <-results
+			if !((a == nil && errors.Is(b, alreadyFulfilled)) || (b == nil && errors.Is(a, alreadyFulfilled))) {
+				t.Fatalf("updates = %v, %v", a, b)
+			}
+		})
+	}
+}
+
+func TestDynamoUpdateRevocationAndExpiry(t *testing.T) {
+	for _, change := range []string{"revoke", "expire", "replace", "abort"} {
+		t.Run(change, func(t *testing.T) {
+			db, svc := testDynamo(t)
+			if err := db.Put("request", yopass.Secret{Message: "pending", Expiration: 3600}); err != nil {
+				t.Fatal(err)
+			}
+			calls := 0
+			abort := errors.New("abort")
+			err := db.Update("request", func(s yopass.Secret) (yopass.Secret, error) {
+				calls++
+				if calls > 1 {
+					return s, abort
+				}
+				switch change {
+				case "revoke":
+					if _, err := db.Delete("request"); err != nil {
+						t.Fatal(err)
+					}
+				case "expire":
+					// Expire the record without changing its revision to exercise
+					// the server-side TTL condition independently of revision CAS.
+					_, err := svc.UpdateItem(&dynamodb.UpdateItemInput{
+						TableName: aws.String(db.tableName), Key: dynamoKey("request"),
+						UpdateExpression:          aws.String("SET #ttl = :expired"),
+						ExpressionAttributeNames:  map[string]*string{"#ttl": aws.String("ttl")},
+						ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{":expired": {N: aws.String("1")}},
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+				case "replace":
+					if err := db.Put("request", yopass.Secret{Message: "replacement", Expiration: 3600}); err != nil {
+						t.Fatal(err)
+					}
+				case "abort":
+					return s, abort
+				}
+				s.Message = "fulfilled"
+				return s, nil
+			})
+			if change == "revoke" || change == "expire" {
+				if !errors.Is(err, server.ErrKeyNotFound) {
+					t.Fatalf("update = %v", err)
+				}
+				if _, err := db.Status("request"); !errors.Is(err, server.ErrKeyNotFound) {
+					t.Fatalf("record resurrected: %v", err)
+				}
+			} else if !errors.Is(err, abort) {
+				t.Fatalf("update = %v", err)
+			} else {
+				want := "pending"
+				if change == "replace" {
+					want = "replacement"
+				}
+				if s, err := db.Status("request"); err != nil || s.Message != want {
+					t.Fatalf("aborted update changed record: %+v, %v", s, err)
+				}
+			}
+		})
+	}
+}
+
+func TestDynamoGetOneTime(t *testing.T) {
+	db, svc := testDynamo(t)
+	if err := db.Put("once", yopass.Secret{Message: "ciphertext", Expiration: 3600, OneTime: true}); err != nil {
+		t.Fatal(err)
+	}
+	db.svc = &simultaneousReads{dynamoClient: svc, key: "once", ready: make(chan struct{})}
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			s, err := db.Get("once")
+			if err != nil && s.Message != "" {
+				t.Error("losing Get returned ciphertext")
+			}
+			results <- err
+		}()
+	}
+	a, b := <-results, <-results
+	if !((a == nil && errors.Is(b, server.ErrKeyNotFound)) || (b == nil && errors.Is(a, server.ErrKeyNotFound))) {
+		t.Fatalf("Get claims = %v, %v", a, b)
+	}
+}
+
+func TestDynamoUpdatePreservesExpiry(t *testing.T) {
+	db, _ := testDynamo(t)
+	if err := db.Put("request", yopass.Secret{Message: "pending", Expiration: 3600}); err != nil {
+		t.Fatal(err)
+	}
+	old, _, err := db.read("request")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = db.Update("request", func(s yopass.Secret) (yopass.Secret, error) {
+		s.Expiration = 604800
+		return s, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, _, err := db.read("request")
+	if err != nil || aws.StringValue(updated["ttl"].N) != aws.StringValue(old["ttl"].N) {
+		t.Fatalf("update extended expiry: %v", err)
+	}
+}
+
+type failingDynamo struct {
+	dynamoClient
+	err error
+}
+
+func (c failingDynamo) DeleteItem(*dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+	return nil, c.err
+}
+
+func TestDynamoDeletePropagatesStorageErrors(t *testing.T) {
+	failure := errors.New("storage unavailable")
+	db := &Dynamo{svc: failingDynamo{err: failure}}
+	if deleted, err := db.Delete("once"); deleted || !errors.Is(err, failure) {
+		t.Fatalf("delete failed open: %v, %v", deleted, err)
+	}
+}

--- a/deploy/cdk/main.go
+++ b/deploy/cdk/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -9,14 +8,9 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/akrylysov/algnhsa"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/jhaals/yopass/pkg/server"
-	"github.com/jhaals/yopass/pkg/yopass"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -188,158 +182,6 @@ func (c *corsWriter) Flush() {
 	if f, ok := c.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
-}
-
-// Dynamo Database implementation
-type Dynamo struct {
-	tableName string
-	svc       *dynamodb.DynamoDB
-}
-
-// NewDynamo returns a database client
-func NewDynamo(tableName string) server.Database {
-	sess, _ := session.NewSession()
-	return &Dynamo{tableName: tableName, svc: dynamodb.New(sess)}
-}
-
-// Get item from dynamo
-func (d *Dynamo) Get(key string) (yopass.Secret, error) {
-	var s yopass.Secret
-	input := &dynamodb.GetItemInput{
-		Key: map[string]*dynamodb.AttributeValue{
-			"id": {
-				S: aws.String(key),
-			},
-		},
-		TableName: aws.String(d.tableName),
-	}
-	result, err := d.svc.GetItem(input)
-	if err != nil {
-		return s, err
-	}
-	if len(result.Item) == 0 {
-		return s, fmt.Errorf("Key not found in database")
-	}
-
-	if *result.Item["one_time"].BOOL {
-		if err := d.deleteItem(key); err != nil {
-			return s, err
-		}
-	}
-	s.Message = *result.Item["secret"].S
-	s.OneTime = *result.Item["one_time"].BOOL
-	if v, ok := result.Item["require_auth"]; ok && v.BOOL != nil {
-		s.RequireAuth = *v.BOOL
-	}
-	return s, nil
-}
-
-// Delete item
-func (d *Dynamo) Delete(key string) (bool, error) {
-	err := d.deleteItem(key)
-
-	if errors.Is(err, &dynamodb.ResourceNotFoundException{}) {
-		return false, nil
-	}
-
-	return err == nil, err
-}
-
-func (d *Dynamo) deleteItem(key string) error {
-	input := &dynamodb.DeleteItemInput{
-		Key: map[string]*dynamodb.AttributeValue{
-			"id": {
-				S: aws.String(key),
-			},
-		},
-		TableName:    aws.String(d.tableName),
-		ReturnValues: aws.String("ALL_OLD"),
-	}
-
-	_, err := d.svc.DeleteItem(input)
-	return err
-}
-
-// Put item in Dynamo
-func (d *Dynamo) Put(key string, secret yopass.Secret) error {
-	input := &dynamodb.PutItemInput{
-		// TABLE GENERATED NAME
-		Item: map[string]*dynamodb.AttributeValue{
-			"id": {
-				S: aws.String(key),
-			},
-			"secret": {
-				S: aws.String(secret.Message),
-			},
-			"one_time": {
-				BOOL: aws.Bool(secret.OneTime),
-			},
-			"require_auth": {
-				BOOL: aws.Bool(secret.RequireAuth),
-			},
-			"ttl": {
-				N: aws.String(
-					fmt.Sprintf(
-						"%d", time.Now().Unix()+int64(secret.Expiration))),
-			},
-		},
-		TableName: aws.String(d.tableName),
-	}
-	_, err := d.svc.PutItem(input)
-	return err
-}
-
-// Status returns the secret without deleting it (safe for one-time secrets).
-// It must include the stored message: secret requests and read receipts load
-// their full JSON records through Status.
-func (d *Dynamo) Status(key string) (yopass.Secret, error) {
-	input := &dynamodb.GetItemInput{
-		Key: map[string]*dynamodb.AttributeValue{
-			"id": {
-				S: aws.String(key),
-			},
-		},
-		TableName: aws.String(d.tableName),
-	}
-	result, err := d.svc.GetItem(input)
-	if err != nil {
-		return yopass.Secret{}, err
-	}
-	if len(result.Item) == 0 {
-		return yopass.Secret{}, fmt.Errorf("Key not found in database")
-	}
-
-	var s yopass.Secret
-	if v, ok := result.Item["secret"]; ok && v.S != nil {
-		s.Message = *v.S
-	}
-	if v, ok := result.Item["one_time"]; ok && v.BOOL != nil {
-		s.OneTime = *v.BOOL
-	}
-	if v, ok := result.Item["require_auth"]; ok && v.BOOL != nil {
-		s.RequireAuth = *v.BOOL
-	}
-	return s, nil
-}
-
-// Update reads the existing secret record, applies fn, and replaces the stored secret.
-func (d *Dynamo) Update(key string, fn func(yopass.Secret) (yopass.Secret, error)) error {
-	s, err := d.Status(key)
-	if err != nil {
-		return err
-	}
-
-	updated, err := fn(s)
-	if err != nil {
-		return err
-	}
-
-	return d.Put(key, updated)
-}
-
-// Dummy health check
-func (d *Dynamo) Health() error {
-    return nil
 }
 
 func configureZapLogger(logLevel zapcore.Level) *zap.Logger {


### PR DESCRIPTION
DynamoDB currently allows concurrent readers to claim the same one-time secret, serves records after their TTL expires, and uses unconditional writes for request updates.

- Make deletion conditional on record existence so only one caller wins a claim.
- Reject expired or invalid TTL records during reads, independently of asynchronous TTL cleanup.
- Use revision-based conditional updates with retries to prevent overwritten fulfillments and resurrection after revocation. Preserve the original expiration and support existing records without revisions.
- Add DynamoDB Local integration coverage and run it in CI.

Validation: `DYNAMODB_ENDPOINT=http://localhost:18000 go test . -race -count=1` passed in `deploy/cdk` against DynamoDB Local. `go test ./cmd/... ./pkg/... -race` passed in the root module. Tests cover concurrent HTTP retrieval of secrets, files, and fulfilled requests; direct one-time reads; expiration; competing updates; revocation; and storage errors.

Deployment: all Lambda instances must run the updated adapter before relying on these guarantees. Existing records acquire revisions on their first conditional update; missing or invalid TTL metadata makes a record unavailable.
