### PR TITLE
Redact bearer identifiers and query strings from HTTP logs

### DIFF
--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -52,7 +52,7 @@ Each event is a single JSON object terminated by a newline (NDJSON). Fields are 
 | `event` | string | yes | Event type (see [Events](#events)) |
 | `outcome` | string | yes | `success`, `failure`, or `denied` |
 | `client_ip` | string | yes | Real client IP, respecting `--trusted-proxies` |
-| `secret_id` | string | no | Key identifying the secret or file |
+| `secret_id` | string | no | First 12 hexadecimal characters of the SHA-256 hash of the secret or file ID |
 | `user_email` | string | no | Authenticated user's email (OIDC sessions only) |
 | `user_subject` | string | no | Authenticated user's OIDC subject claim |
 | `one_time` | bool | no | Whether the secret was configured for one-time access |
@@ -60,18 +60,18 @@ Each event is a single JSON object terminated by a newline (NDJSON). Fields are 
 | `require_auth` | bool | no | Whether the secret requires OIDC authentication to access |
 | `error` | string | no | Human-readable reason for `failure` or `denied` outcomes |
 
-> **Privacy note:** Encrypted secret content is never written to the audit log — only the key (ID) and metadata are recorded.
+> **Privacy note:** Encrypted secret content is never written to the audit log — only a hashed ID and metadata are recorded.
 
 ### Example records
 
 Successful secret creation:
 ```json
-{"timestamp":"2026-04-09T12:00:01.123456789Z","event":"secret.created","outcome":"success","client_ip":"203.0.113.42","secret_id":"k9bXz3mQ2vR7nLpA4wEy5a","one_time":true,"expiration_seconds":3600,"require_auth":false,"user_email":"alice@corp.example","user_subject":"auth0|abc123"}
+{"timestamp":"2026-04-09T12:00:01.123456789Z","event":"secret.created","outcome":"success","client_ip":"203.0.113.42","secret_id":"3a128f193823","one_time":true,"expiration_seconds":3600,"require_auth":false,"user_email":"alice@corp.example","user_subject":"auth0|abc123"}
 ```
 
 Access denied (unauthenticated):
 ```json
-{"timestamp":"2026-04-09T12:01:00.000000001Z","event":"secret.accessed","outcome":"denied","client_ip":"198.51.100.7","secret_id":"k9bXz3mQ2vR7nLpA4wEy5a","require_auth":true,"error":"authentication required"}
+{"timestamp":"2026-04-09T12:01:00.000000001Z","event":"secret.accessed","outcome":"denied","client_ip":"198.51.100.7","secret_id":"3a128f193823","require_auth":true,"error":"authentication required"}
 ```
 
 Successful login:
@@ -112,6 +112,24 @@ Successful login:
 - `success` — operation completed normally
 - `failure` — operation failed (validation error, database error, not found)
 - `denied` — operation was rejected due to missing or insufficient authentication
+
+---
+
+## HTTP access logs
+
+Regular HTTP access logs are redacted regardless of whether licensed audit
+logging is enabled. The `uri` field contains the route template, such as
+`/secret/{key}/status`, and `secret_id` contains the same truncated SHA-256 hash
+used by audit logs. Raw identifiers and URL query strings are omitted, including
+OIDC callback codes and state parameters. Unmatched requests log `unmatched`;
+requests handled by the static-file fallback log `/` without the requested
+filename.
+
+Apply equivalent redaction to reverse proxies, API Gateway access logs, and log
+collectors: application redaction cannot remove URLs recorded by those systems.
+Existing logs may still contain usable identifiers until the associated secrets
+expire or are consumed; restrict access and handle those logs under your
+credential-exposure policy.
 
 ---
 

--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -119,8 +119,11 @@ Successful login:
 
 Regular HTTP access logs are redacted regardless of whether licensed audit
 logging is enabled. The `uri` field contains the route template, such as
-`/secret/{key}/status`, and `secret_id` contains the same truncated SHA-256 hash
-used by audit logs. Raw identifiers and URL query strings are omitted, including
+`/secret/{key}/status`. Only routes with a `{key}` parameter include `secret_id`,
+which contains the same truncated SHA-256 hash used by audit logs. Routes such as
+`/config` and `/auth/callback` omit that field.
+
+Raw identifiers and URL query strings are omitted, including
 OIDC callback codes and state parameters. Unmatched requests log `unmatched`;
 requests handled by the static-file fallback log `/` without the requested
 filename.

--- a/pkg/server/logging.go
+++ b/pkg/server/logging.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 )
 
@@ -46,9 +47,11 @@ func (y *Server) isTrustedProxy(remoteIP string) bool {
 	return false
 }
 
-// httpLogFormatter returns a logging formatter that uses the real client IP,
-// resolving X-Forwarded-For only when the request comes from a trusted proxy.
-func (y *Server) httpLogFormatter() func(io.Writer, handlers.LogFormatterParams) {
+// httpLogFormatter records route templates rather than request URLs: path keys
+// are bearer capabilities and query strings may contain OIDC codes. Matching
+// again is necessary because mux attaches route metadata to a request copy that
+// the outer logging handler cannot see. Never fall back to the raw URL.
+func (y *Server) httpLogFormatter(router *mux.Router) func(io.Writer, handlers.LogFormatterParams) {
 	logger := y.Logger
 	if logger == nil {
 		logger = zap.NewNop()
@@ -57,22 +60,23 @@ func (y *Server) httpLogFormatter() func(io.Writer, handlers.LogFormatterParams)
 	return func(_ io.Writer, params handlers.LogFormatterParams) {
 		req := params.Request
 		if req == nil {
-			logger.Error("Unable to log request: no request in params",
-				zap.Reflect("LogFormatterParams", params),
-			)
+			logger.Error("Unable to log request: no request in params")
 			return
 		}
 
-		uri := req.RequestURI
-		// HTTP/2 CONNECT uses the authority field instead of a request URI.
-		if req.ProtoMajor == 2 && req.Method == "CONNECT" {
-			uri = req.Host
-		}
-		if uri == "" {
-			uri = params.URL.RequestURI()
+		uri := "unmatched"
+		var secretID string
+		var match mux.RouteMatch
+		if router != nil && req.URL != nil && router.Match(req, &match) && match.Route != nil {
+			if template, err := match.Route.GetPathTemplate(); err == nil {
+				uri = strings.ReplaceAll(template, keyParameter, "{key}")
+			}
+			if key := match.Vars["key"]; key != "" {
+				secretID = redactSecretID(key)
+			}
 		}
 
-		logger.Info("Request handled",
+		fields := []zap.Field{
 			zap.String("host", y.getRealClientIP(req)),
 			zap.Time("timestamp", params.TimeStamp),
 			zap.String("method", req.Method),
@@ -80,6 +84,10 @@ func (y *Server) httpLogFormatter() func(io.Writer, handlers.LogFormatterParams)
 			zap.String("protocol", req.Proto),
 			zap.Int("responseStatus", params.StatusCode),
 			zap.Int("responseSize", params.Size),
-		)
+		}
+		if secretID != "" {
+			fields = append(fields, zap.String("secret_id", secretID))
+		}
+		logger.Info("Request handled", fields...)
 	}
 }

--- a/pkg/server/logging_test.go
+++ b/pkg/server/logging_test.go
@@ -1,12 +1,18 @@
 package server
 
 import (
+	"encoding/json"
 	"net"
+	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+	"github.com/jhaals/yopass/pkg/yopass"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -89,7 +95,135 @@ func TestGetRealClientIP(t *testing.T) {
 	}
 }
 
+func TestHTTPAccessLogsRedactCapabilities(t *testing.T) {
+	for _, id := range []string{"12345678-1234-1234-1234-123456789012", "AbCdEf0123456789GhIjKl"} {
+		for _, endpoint := range []struct{ method, path, want string }{
+			{"GET", "/secret/", "/secret/{key}"},
+			{"DELETE", "/secret/", "/secret/{key}"},
+			{"GET", "/secret/%s/status", "/secret/{key}/status"},
+			{"GET", "/secret/%s/receipt", "/secret/{key}/receipt"},
+			{"GET", "/file/", "/file/{key}"},
+			{"DELETE", "/file/", "/file/{key}"},
+			{"OPTIONS", "/file/", "/file/{key}"},
+			{"GET", "/file/%s/status", "/file/{key}/status"},
+			{"GET", "/file/%s/receipt", "/file/{key}/receipt"},
+			{"GET", "/request/", "/request/{key}"},
+			{"DELETE", "/request/", "/request/{key}"},
+			{"GET", "/request/%s/secret", "/request/{key}/secret"},
+			{"POST", "/request/%s/secret", "/request/{key}/secret"},
+			{"PUT", "/request/%s/key", "/request/{key}/key"},
+		} {
+			t.Run(id+endpoint.method+endpoint.want, func(t *testing.T) {
+				core, logs := observer.New(zap.DebugLevel)
+				db := newMemoryDB()
+				// Include a successful public read and a denied protected file
+				// read; remaining probes exercise missing/invalid request paths.
+				if err := db.Put(id, yopass.Secret{Message: "encrypted-content"}); err != nil {
+					t.Fatal(err)
+				}
+				if err := db.Put(streamKeyPrefix+id, yopass.Secret{RequireAuth: true}); err != nil {
+					t.Fatal(err)
+				}
+				y := newRequestTestServer(t, db, true)
+				y.Logger, y.PrefetchSecret = zap.New(core), true
+				y.AssetPath = t.TempDir()
+				path := endpoint.path + id
+				if strings.Contains(endpoint.path, "%s") {
+					path = strings.ReplaceAll(endpoint.path, "%s", id)
+				}
+				r := httptest.NewRequest(endpoint.method, path+"?code=private-code&token=private-token", strings.NewReader("{}"))
+				r.Header.Set("Authorization", "Bearer private-bearer")
+				r.Header.Set("X-Yopass-Request-Token", "private-management-token")
+				w := httptest.NewRecorder()
+				y.HTTPHandler().ServeHTTP(w, r)
+				entries := logs.FilterMessage("Request handled").All()
+				if len(entries) != 1 {
+					t.Fatalf("access log count = %d", len(entries))
+				}
+				fields := entries[0].ContextMap()
+				assert.Equal(t, endpoint.want, fields["uri"])
+				assert.Equal(t, redactSecretID(id), fields["secret_id"])
+				assert.Equal(t, int64(w.Code), fields["responseStatus"])
+				for _, entry := range logs.All() {
+					encoded, err := json.Marshal(entry.ContextMap())
+					if err != nil {
+						t.Fatal(err)
+					}
+					for _, sensitive := range []string{id, "private-code", "private-token", "private-bearer", "private-management-token", "encrypted-content"} {
+						assert.NotContains(t, string(encoded), sensitive)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestHTTPLogFormatterNeverFallsBackToRawURL(t *testing.T) {
+	router := mux.NewRouter()
+	router.HandleFunc("/secret/"+keyParameter, func(http.ResponseWriter, *http.Request) {}).Methods("GET")
+	router.HandleFunc("/auth/callback", func(http.ResponseWriter, *http.Request) {}).Methods("GET")
+	router.HandleFunc("/config", func(http.ResponseWriter, *http.Request) {}).Methods("GET")
+	const id = "12345678-1234-1234-1234-123456789012"
+	for _, tc := range []struct{ method, target, want string }{
+		{"GET", "/auth/callback?code=private-code&state=private-state", "/auth/callback"},
+		{"GET", "/config?token=private-token", "/config"},
+		{"GET", "/%73ecret/" + id, "/secret/{key}"},
+		{"GET", "/secret/%31" + id[1:], "/secret/{key}"},
+		{"GET", "https://private-user:private-password@example.com/secret/" + id + "?code=private-code", "/secret/{key}"},
+		{"POST", "/secret/" + id, "unmatched"},
+		{"GET", "/secret/" + id + "/unknown", "unmatched"},
+		{"GET", "/private-token", "unmatched"},
+		{"CONNECT", "/private-token", "unmatched"},
+	} {
+		t.Run(tc.method+tc.target, func(t *testing.T) {
+			core, logs := observer.New(zap.DebugLevel)
+			y := &Server{Logger: zap.New(core)}
+			r := httptest.NewRequest(tc.method, tc.target, nil)
+			r.ProtoMajor = 2
+			r.Host = "private-host"
+			for _, emptyURI := range []bool{false, true} {
+				if emptyURI {
+					r.RequestURI = ""
+				}
+				y.httpLogFormatter(router)(nil, handlers.LogFormatterParams{
+					Request: r, URL: *r.URL, StatusCode: 404,
+				})
+				entry := logs.TakeAll()[0]
+				fields := entry.ContextMap()
+				assert.Equal(t, tc.want, fields["uri"])
+				encoded, err := json.Marshal(fields)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assert.NotContains(t, string(encoded), id)
+				assert.NotContains(t, string(encoded), "private-")
+			}
+		})
+	}
+	core, logs := observer.New(zap.DebugLevel)
+	y := &Server{Logger: zap.New(core)}
+	// The missing-request error path must not serialize params.URL either.
+	y.httpLogFormatter(router)(nil, handlers.LogFormatterParams{URL: url.URL{Path: "/secret/" + id, RawQuery: "code=private-code"}})
+	assert.Empty(t, logs.All()[0].ContextMap())
+}
+
+func TestHTTPAccessLogStaticFallback(t *testing.T) {
+	core, logs := observer.New(zap.DebugLevel)
+	y := newRequestTestServer(t, newMemoryDB(), false)
+	y.Logger, y.AssetPath = zap.New(core), t.TempDir()
+	w := httptest.NewRecorder()
+	y.HTTPHandler().ServeHTTP(w, httptest.NewRequest("GET", "/unknown/private-token?code=private-code", nil))
+	entries := logs.FilterMessage("Request handled").All()
+	if len(entries) != 1 {
+		t.Fatalf("access log count = %d", len(entries))
+	}
+	assert.Equal(t, "/", entries[0].ContextMap()["uri"])
+	assert.NotContains(t, entries[0].ContextMap(), "secret_id")
+}
+
 func TestHTTPLogFormatter(t *testing.T) {
+	router := mux.NewRouter()
+	router.HandleFunc("/", func(http.ResponseWriter, *http.Request) {})
 	t.Run("Log request with no trusted proxies", func(t *testing.T) {
 		ts := time.Now()
 		request := httptest.NewRequest("GET", "https://yopass.se/", nil)
@@ -104,7 +238,7 @@ func TestHTTPLogFormatter(t *testing.T) {
 			TrustedProxies: []string{}, // No trusted proxies
 		}
 
-		formatter := server.httpLogFormatter()
+		formatter := server.httpLogFormatter(router)
 		formatter(nil, handlers.LogFormatterParams{
 			Request:    request,
 			TimeStamp:  ts,
@@ -132,7 +266,7 @@ func TestHTTPLogFormatter(t *testing.T) {
 			case "method":
 				assert.Equal(t, "GET", f.String)
 			case "uri":
-				assert.Equal(t, "https://yopass.se/", f.String)
+				assert.Equal(t, "/", f.String)
 			case "protocol":
 				assert.Equal(t, "HTTP/1.1", f.String)
 			case "responseStatus":
@@ -163,7 +297,7 @@ func TestHTTPLogFormatter(t *testing.T) {
 			TrustedProxies: []string{"192.168.1.100"}, // Trust this proxy
 		}
 
-		formatter := server.httpLogFormatter()
+		formatter := server.httpLogFormatter(router)
 		formatter(nil, handlers.LogFormatterParams{
 			Request:    request,
 			TimeStamp:  ts,
@@ -190,7 +324,7 @@ func TestHTTPLogFormatter(t *testing.T) {
 			case "method":
 				assert.Equal(t, "GET", f.String)
 			case "uri":
-				assert.Equal(t, "https://yopass.se/", f.String)
+				assert.Equal(t, "/", f.String)
 			case "protocol":
 				assert.Equal(t, "HTTP/1.1", f.String)
 			case "responseStatus":
@@ -215,7 +349,7 @@ func TestHTTPLogFormatter(t *testing.T) {
 			Logger: logger,
 		}
 
-		formatter := server.httpLogFormatter()
+		formatter := server.httpLogFormatter(router)
 		formatter(nil, handlers.LogFormatterParams{})
 
 		if err := logger.Sync(); err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -691,7 +691,7 @@ func (y *Server) HTTPHandler() http.Handler {
 			extraImgSrc = []string{u.Scheme + "://" + u.Host}
 		}
 	}
-	return handlers.CustomLoggingHandler(nil, SecurityHeadersHandler(extraImgSrc, y.Argon2, mx), y.httpLogFormatter())
+	return handlers.CustomLoggingHandler(nil, SecurityHeadersHandler(extraImgSrc, y.Argon2, mx), y.httpLogFormatter(mx))
 }
 
 const keyParameter = "{key:(?:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}|[a-zA-Z0-9]{22})}"

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1264,11 +1264,11 @@ func TestConfigHandlerForceOnetimeSecrets(t *testing.T) {
 func TestHTTPLogFormatterEdgeCases(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	server := &Server{Logger: logger}
-	formatter := server.httpLogFormatter()
+	formatter := server.httpLogFormatter(nil)
 
 	// Test with nil logger
 	nilServer := &Server{Logger: nil}
-	nilFormatter := nilServer.httpLogFormatter()
+	nilFormatter := nilServer.httpLogFormatter(nil)
 	if nilFormatter == nil {
 		t.Error("Formatter should not be nil even with nil logger")
 	}


### PR DESCRIPTION
HTTP access logs currently expose raw secret and request identifiers, allowing log readers to consume public secrets or sabotage requests.

Query strings, including OIDC callback codes and state, are omitted. Unmatched requests and static-file fallback requests never fall back to raw URLs. The missing-request error path no longer serializes request parameters. Documentation explains the log format and the need for equivalent redaction in upstream infrastructure.

Validation: log-redaction regression tests passed with the race detector, covering secret/file/request routes, successful and rejected requests, encoded paths, absolute URLs, query parameters, and fallback paths. `go test ./cmd/... ./pkg/... -race` and `go test . -race` in `deploy/cdk` both passed.

The `uri` field now contains a route template; requests with a key also include the same truncated SHA-256 `secret_id` used by audit logs. Previously written logs and upstream proxy logs are unaffected.
