### PR TITLE
Deploy frontends to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-cloudflare-share.yml
+++ b/.github/workflows/deploy-cloudflare-share.yml
@@ -1,0 +1,55 @@
+name: Deploy sharing app to Cloudflare Pages
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "website/**"
+      - ".github/workflows/deploy-cloudflare-share.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    name: Deploy sharing app
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    environment: Deploy
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "yarn"
+          cache-dependency-path: website/yarn.lock
+
+      - name: Install dependencies
+        working-directory: website
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        working-directory: website
+        run: yarn build
+        env:
+          YOPASS_BACKEND_URL: "http://api2.yopass.se"
+
+      - name: Add Cloudflare Pages headers
+        working-directory: website
+        run: cp cloudflare-pages-headers dist/_headers
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=yopass-share
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          packageManager: npm
+          workingDirectory: website
+          wranglerVersion: "4.81.0"

--- a/.github/workflows/deploy-cloudflare-site.yml
+++ b/.github/workflows/deploy-cloudflare-site.yml
@@ -1,0 +1,50 @@
+name: Deploy landing site to Cloudflare Pages
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "microsite/**"
+      - "docs/**"
+      - ".github/workflows/deploy-cloudflare-site.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    name: Deploy landing site
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    environment: Deploy
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: microsite/package-lock.json
+
+      - name: Install dependencies
+        working-directory: microsite
+        run: npm ci
+
+      - name: Build
+        working-directory: microsite
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy build --project-name=yopass-site
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          packageManager: npm
+          workingDirectory: microsite
+          wranglerVersion: "4.81.0"

--- a/website/cloudflare-pages-headers
+++ b/website/cloudflare-pages-headers
@@ -1,0 +1,6 @@
+/*
+  Content-Security-Policy: connect-src 'self' https://api.yopass.se https://api2.yopass.se; default-src 'self'; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; upgrade-insecure-requests
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: no-referrer


### PR DESCRIPTION
## Summary
- deploy the sharing app and landing site to separate Cloudflare Pages projects
- preserve the sharing app CSP and security headers
- limit deployments to changes in each frontend and its deployment workflow
- leave the existing Netlify deployments unchanged

## Validation
- website production build
- microsite production build
- website lint, typecheck, and 39 unit tests
- yamllint and actionlint for both workflows