### PR TITLE
CI: move Cloudflare deploys to Node 24 actions

### DIFF
--- a/.github/workflows/deploy-cloudflare-share.yml
+++ b/.github/workflows/deploy-cloudflare-share.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: Deploy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "yarn"

--- a/.github/workflows/deploy-cloudflare-site.yml
+++ b/.github/workflows/deploy-cloudflare-site.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: Deploy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: microsite/package-lock.json
 


### PR DESCRIPTION
## Summary
- update checkout and setup-node actions to Node 24-based releases
- build the landing site with Node 24 to match the sharing app
- remove the Node 20 deprecation warnings from both Cloudflare deploy workflows

## Validation
- yamllint
- actionlint
- microsite production build